### PR TITLE
Add support bot with ticketing tunnel and web chat widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ Supports **Laravel 10 → 13**, PHP 8.2+, and includes production-only mode so n
   - [Activity Log](#activity-log)
     - [HasTelegramActivity Trait](#hastelegramactivity-trait)
     - [TelegramActivity Facade](#telegramactivity-facade)
+- [Support Bot (Ticketing Tunnel)](#support-bot-ticketing-tunnel)
+  - [Quick Setup](#quick-setup)
+  - [Agent Commands](#agent-commands-in-the-staff-group)
+  - [Artisan Commands](#artisan-commands-1)
+  - [Supported Media Types](#supported-media-types)
+  - [TelegramSupport Facade](#telegramsupport-facade)
 - [Artisan Commands](#artisan-commands)
 - [Log Levels](#log-levels)
 - [Getting Telegram Credentials](#getting-telegram-credentials)
@@ -42,6 +48,7 @@ Supports **Laravel 10 → 13**, PHP 8.2+, and includes production-only mode so n
 - **Monolog integration** — drop-in `telegram` log channel; works with `LOG_CHANNEL=telegram` or as a stacked channel
 - **Direct messaging** — send arbitrary text to any chat from anywhere in your app
 - **Activity log** — track Eloquent model `created / updated / deleted` events and push them to Telegram (inspired by [spatie/laravel-activitylog](https://github.com/spatie/laravel-activitylog))
+- **Support bot / ticketing tunnel** — user DMs become tickets forwarded to a staff group; agent replies are relayed back automatically, with full document/media support
 - **Production-only mode** — restrict notifications to specific environments with a single env var
 - **Smart formatting** — emoji-labelled MarkdownV2 messages with context, exception details, and stack traces
 - **Long message splitting** — automatically splits messages that exceed Telegram's 4096-char limit
@@ -385,9 +392,177 @@ php artisan telegramlogs:test --list
 
 ---
 
+## Support Bot (Ticketing Tunnel)
+
+The package includes a full **user ↔ agent support tunnel** built on top of Telegram.
+
+```
+User → DM to bot → ticket created → message forwarded to staff group
+Agent → reply in group             → bot relays reply to user's private chat
+```
+
+All media types are supported: text, photos, documents, videos, voice messages, audio files, stickers.
+
+---
+
+### Architecture
+
+```
+[User private chat]          [Staff group]
+      User ──────────────►  🎫 Ticket #0001
+                             👤 Alice (@alice)
+                             📅 28/05/2026 14:30
+                             💬 "J'ai un problème..."
+                                    │
+      User ◄──────────────  Agent replies with /reply ──► bot forwards to user
+```
+
+Each ticket is stored in the database with a mapping between the group message ID and the user's Telegram ID. Agents reply using Telegram's native **Reply** feature — no slash commands needed to answer.
+
+---
+
+### Quick Setup
+
+**1. Run the setup guide:**
+
+```bash
+php artisan telegram:support setup
+```
+
+**2. Add environment variables:**
+
+```env
+# Required
+TELEGRAM_SUPPORT_BOT_TOKEN=123456:ABC-your-support-bot-token
+TELEGRAM_SUPPORT_GROUP_ID=-1001234567890
+
+# Strongly recommended
+TELEGRAM_SUPPORT_WEBHOOK_SECRET=a-long-random-secret-string
+
+# Optional
+TELEGRAM_SUPPORT_WEBHOOK_PATH=/telegram/support/webhook
+```
+
+**3. Publish and run migrations:**
+
+```bash
+php artisan vendor:publish --tag=telegramlogs-support-migrations
+php artisan migrate
+```
+
+**4. Exclude the webhook route from CSRF** (in `bootstrap/app.php` for Laravel 11+ or `VerifyCsrfToken` middleware):
+
+```php
+// Laravel 11+ — bootstrap/app.php
+->withMiddleware(function (Middleware $middleware) {
+    $middleware->validateCsrfTokens(except: [
+        '/telegram/support/webhook',
+    ]);
+})
+
+// Laravel 10 — App\Http\Middleware\VerifyCsrfToken
+protected $except = [
+    '/telegram/support/webhook',
+];
+```
+
+**5. Register the webhook:**
+
+```bash
+php artisan telegram:support webhook-set --url=https://yourapp.com/telegram/support/webhook
+```
+
+---
+
+### Environment Variables Reference
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `TELEGRAM_SUPPORT_BOT_TOKEN` | Yes | — | Bot token for the support bot |
+| `TELEGRAM_SUPPORT_GROUP_ID` | Yes | — | Numeric ID of the staff group (starts with -100) |
+| `TELEGRAM_SUPPORT_WEBHOOK_SECRET` | Recommended | `null` | Secret to validate incoming Telegram requests |
+| `TELEGRAM_SUPPORT_WEBHOOK_PATH` | No | `/telegram/support/webhook` | URL path for the webhook |
+
+---
+
+### Agent Commands (in the staff group)
+
+Agents work by using Telegram's native **Reply** feature. Reply to any ticket message to send a response to the user. Additionally:
+
+| Command | Usage |
+|---------|-------|
+| `/status` | Reply to a ticket message to see ticket details (user info, message count, dates) |
+| `/close` | Reply to a ticket message to close it and notify the user |
+
+---
+
+### Artisan Commands
+
+```bash
+# Interactive setup guide
+php artisan telegram:support setup
+
+# Register the webhook with Telegram
+php artisan telegram:support webhook-set --url=https://yourapp.com/telegram/support/webhook
+
+# Remove the webhook
+php artisan telegram:support webhook-delete
+
+# Check bot connection and ticket stats
+php artisan telegram:support status
+
+# List recent tickets
+php artisan telegram:support tickets --limit=50
+```
+
+---
+
+### User Commands (in the private chat)
+
+| Command | Description |
+|---------|-------------|
+| `/start` | Welcome message |
+| `/status` | Show the user's current open ticket status |
+| `/help` | Display help message |
+
+---
+
+### Supported Media Types
+
+Users can send all Telegram media types — the bot relays them transparently to the staff group and vice versa:
+
+- Text messages
+- Photos
+- Documents (PDF, DOCX, ZIP, etc.)
+- Videos
+- Audio files
+- Voice messages
+- Stickers
+- Circular video notes
+
+---
+
+### TelegramSupport Facade
+
+```php
+use TelegramSupport;
+
+// Check bot info
+TelegramSupport::getBotInfo();
+
+// Register webhook programmatically
+TelegramSupport::setWebhook('https://yourapp.com/telegram/support/webhook', $secret);
+
+// Process an update manually (useful for testing)
+TelegramSupport::processUpdate($update);
+```
+
+---
+
 ## Security
 
 - Store `TELEGRAM_BOT_TOKEN` only in `.env` — never commit it
+- Set `TELEGRAM_SUPPORT_WEBHOOK_SECRET` in production to prevent spoofed requests
 - Restrict which commands the bot can receive (via BotFather → `/mybots → Bot Settings → Group Privacy`)
 - Audit who has access to your Telegram channel regularly
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Supports **Laravel 10 → 13**, PHP 8.2+, and includes production-only mode so n
     - [HasTelegramActivity Trait](#hastelegramactivity-trait)
     - [TelegramActivity Facade](#telegramactivity-facade)
 - [Support Bot (Ticketing Tunnel)](#support-bot-ticketing-tunnel)
+  - [Multiple Bots (logs vs support)](#multiple-bots-logs-vs-support)
   - [Quick Setup](#quick-setup)
   - [Agent Commands](#agent-commands-in-the-staff-group)
   - [Artisan Commands](#artisan-commands-1)
@@ -49,6 +50,7 @@ Supports **Laravel 10 → 13**, PHP 8.2+, and includes production-only mode so n
 - **Direct messaging** — send arbitrary text to any chat from anywhere in your app
 - **Activity log** — track Eloquent model `created / updated / deleted` events and push them to Telegram (inspired by [spatie/laravel-activitylog](https://github.com/spatie/laravel-activitylog))
 - **Support bot / ticketing tunnel** — user DMs become tickets forwarded to a staff group; agent replies are relayed back automatically, with full document/media support
+- **Single or multiple bots** — one bot handles everything by default; split logs and support across dedicated bots whenever you need to, with automatic fallback
 - **Production-only mode** — restrict notifications to specific environments with a single env var
 - **Smart formatting** — emoji-labelled MarkdownV2 messages with context, exception details, and stack traces
 - **Long message splitting** — automatically splits messages that exceed Telegram's 4096-char limit
@@ -421,6 +423,64 @@ Each ticket is stored in the database with a mapping between the group message I
 
 ---
 
+### Multiple Bots (logs vs support)
+
+By default the package runs with **one bot**: `TELEGRAM_BOT_TOKEN` powers the log channel, direct messages, the support ticket bot, and the web chat widget. You don't need to configure anything to stay single-bot.
+
+When you'd rather keep a quiet internal **logs** bot separate from a customer-facing **support** bot, give the support role its own token:
+
+```env
+# Default bot — logs, direct messages, activity log
+TELEGRAM_BOT_TOKEN=111111:AAA-logs-bot-token
+
+# Dedicated support bot — ticketing + web chat (optional)
+TELEGRAM_SUPPORT_BOT_TOKEN=222222:BBB-support-bot-token
+```
+
+Tokens are resolved per *role* in `config/telegramlogs.php`. Any role left empty transparently inherits the `default` bot:
+
+```php
+'bots' => [
+    'default' => ['token' => env('TELEGRAM_BOT_TOKEN')],
+    'support' => ['token' => env('TELEGRAM_SUPPORT_BOT_TOKEN')], // empty → uses default
+],
+```
+
+| Role | Used by | Falls back to |
+|------|---------|---------------|
+| `default` | log channel, `TelegramMessage`, activity log | — |
+| `support` | support ticket bot + web chat widget | `default` |
+
+**Add your own roles** for any extra bots, then resolve their tokens anywhere:
+
+```php
+use Uzhlaravel\Telegramlogs\BotRegistry;
+
+$token = BotRegistry::token('marketing');   // your custom role, falls back to default
+BotRegistry::hasDedicatedBot('support');     // true only if support has its own token
+BotRegistry::isSingleBotMode();              // true when every role shares the default bot
+```
+
+Inspect your current topology at any time:
+
+```bash
+php artisan telegram:support status
+```
+
+```
+Bot mode: single-bot
++---------+--------------+-------------------+
+| Role    | Token        | Resolution        |
++---------+--------------+-------------------+
+| default | ✅ configured | —                 |
+| support | ✅ configured | inherits default  |
++---------+--------------+-------------------+
+```
+
+> Using two bots? Each bot is a separate Telegram identity, so create both via @BotFather. Only the **support** bot needs a webhook and must be an admin of the staff group; the logs bot only sends messages outbound.
+
+---
+
 ### Quick Setup
 
 **1. Run the setup guide:**
@@ -478,10 +538,12 @@ php artisan telegram:support webhook-set --url=https://yourapp.com/telegram/supp
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `TELEGRAM_SUPPORT_BOT_TOKEN` | Yes | — | Bot token for the support bot |
 | `TELEGRAM_SUPPORT_GROUP_ID` | Yes | — | Numeric ID of the staff group (starts with -100) |
+| `TELEGRAM_SUPPORT_BOT_TOKEN` | No | falls back to `TELEGRAM_BOT_TOKEN` | Dedicated support bot token. Leave empty to reuse the default bot (single-bot mode) |
 | `TELEGRAM_SUPPORT_WEBHOOK_SECRET` | Recommended | `null` | Secret to validate incoming Telegram requests |
 | `TELEGRAM_SUPPORT_WEBHOOK_PATH` | No | `/telegram/support/webhook` | URL path for the webhook |
+
+> **Single bot by default.** If you only set `TELEGRAM_BOT_TOKEN`, the same bot handles logs **and** support. See [Multiple Bots](#multiple-bots-logs-vs-support) to split them.
 
 ---
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,12 @@
         "realtime",
         "markdown",
         "threaded discussions",
-        "Activity logs"
+        "Activity logs",
+        "support bot",
+        "ticketing",
+        "web chat",
+        "chat widget",
+        "livechat"
     ],
     "homepage": "https://github.com/Uzziahlukeka/telegrammonitor",
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,10 @@
         "illuminate/contracts": "^10.0||^11.0||^12.0||^13.0",
         "illuminate/database": "^10.0||^11.0||^12.0||^13.0",
         "illuminate/events": "^10.0||^11.0||^12.0||^13.0",
-        "illuminate/support": "^10.0||^11.0||^12.0||^13.0"
+        "illuminate/http": "^10.0||^11.0||^12.0||^13.0",
+        "illuminate/routing": "^10.0||^11.0||^12.0||^13.0",
+        "illuminate/support": "^10.0||^11.0||^12.0||^13.0",
+        "guzzlehttp/guzzle": "^7.0"
     },
     "require-dev": {
         "larastan/larastan": "^3.6",
@@ -79,7 +82,8 @@
             "aliases": {
                 "Telegramlogs": "Uzhlaravel\\Telegramlogs\\Facades\\Telegramlogs",
                 "TelegramMessage": "Uzhlaravel\\Telegramlogs\\Facades\\TelegramMessage",
-                "TelegramActivity": "Uzhlaravel\\Telegramlogs\\Facades\\TelegramActivity"
+                "TelegramActivity": "Uzhlaravel\\Telegramlogs\\Facades\\TelegramActivity",
+                "TelegramSupport": "Uzhlaravel\\Telegramlogs\\Facades\\TelegramSupport"
             }
         }
     },

--- a/config/telegramlogs.php
+++ b/config/telegramlogs.php
@@ -231,6 +231,79 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Telegram Support Bot (Ticketing System)
+    |--------------------------------------------------------------------------
+    |
+    | This section powers the user ↔ agent tunnel:
+    |   User DMs the bot → ticket created → forwarded to staff group
+    |   Agent replies in group → bot relays reply to user's private chat
+    |
+    | Setup: php artisan telegram:support setup
+    |
+    */
+    'support_bot' => [
+
+        /*
+        |----------------------------------------------------------------------
+        | Support Bot Token
+        |----------------------------------------------------------------------
+        |
+        | Token for the support bot. Can be the same bot as the log bot or
+        | a dedicated one — a separate bot is recommended for clarity.
+        |
+        */
+        'bot_token' => env('TELEGRAM_SUPPORT_BOT_TOKEN', env('TELEGRAM_BOT_TOKEN')),
+
+        /*
+        |----------------------------------------------------------------------
+        | Staff Group ID
+        |----------------------------------------------------------------------
+        |
+        | Numeric ID of the private Telegram group where agents work.
+        | Supergroup IDs start with -100 (e.g. -1001234567890).
+        | The bot must be an admin of this group.
+        |
+        */
+        'group_id' => env('TELEGRAM_SUPPORT_GROUP_ID'),
+
+        /*
+        |----------------------------------------------------------------------
+        | Webhook Path
+        |----------------------------------------------------------------------
+        |
+        | The URL path that Telegram will POST updates to.
+        | Make sure this route is publicly accessible and excluded from CSRF.
+        |
+        */
+        'webhook_path' => env('TELEGRAM_SUPPORT_WEBHOOK_PATH', '/telegram/support/webhook'),
+
+        /*
+        |----------------------------------------------------------------------
+        | Webhook Secret Token
+        |----------------------------------------------------------------------
+        |
+        | Optional random string used to validate that incoming webhook
+        | requests are genuinely from Telegram (X-Telegram-Bot-Api-Secret-Token).
+        | Strongly recommended in production.
+        |
+        */
+        'webhook_secret' => env('TELEGRAM_SUPPORT_WEBHOOK_SECRET'),
+
+        /*
+        |----------------------------------------------------------------------
+        | Bot Messages (customisable)
+        |----------------------------------------------------------------------
+        */
+        'messages' => [
+            'welcome' => env('TELEGRAM_SUPPORT_MSG_WELCOME'),
+            'ticket_created' => env('TELEGRAM_SUPPORT_MSG_CREATED'),
+            'ticket_closed' => env('TELEGRAM_SUPPORT_MSG_CLOSED'),
+            'help' => env('TELEGRAM_SUPPORT_MSG_HELP'),
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Logging Channels Configuration
     |--------------------------------------------------------------------------
     |

--- a/config/telegramlogs.php
+++ b/config/telegramlogs.php
@@ -49,19 +49,32 @@ return [
     |   default → logs channel, TelegramMessage, activity log
     |   support → support ticket bot + web chat widget
     |
-    | You may add custom roles here too; resolve them with:
+    | You may add as many custom roles as you need. Resolve any role with:
     |   Uzhlaravel\Telegramlogs\BotRegistry::token('your-role')
+    |   TelegramMessage::forRole('your-role')->toChat('-100xxx', 'msg')
+    |
+    | Example with 3 bots:
+    |   TELEGRAM_BOT_TOKEN          → internal logs & monitoring
+    |   TELEGRAM_SUPPORT_BOT_TOKEN  → customer-facing support / web chat
+    |   TELEGRAM_NOTIF_BOT_TOKEN    → your own third role (notifications, etc.)
     |
     */
     'bots' => [
+        // Powers: log channel, TelegramMessage (default), activity log.
         'default' => [
             'token' => env('TELEGRAM_BOT_TOKEN'),
         ],
 
-        // Leave empty to reuse the default bot for support.
+        // Powers: support ticket bot + web chat widget.
+        // Leave empty → falls back to the default bot (single-bot mode).
         'support' => [
             'token' => env('TELEGRAM_SUPPORT_BOT_TOKEN'),
         ],
+
+        // Add any extra role you need; empty = inherits default bot.
+        // 'notifications' => [
+        //     'token' => env('TELEGRAM_NOTIF_BOT_TOKEN'),
+        // ],
     ],
 
     /*

--- a/config/telegramlogs.php
+++ b/config/telegramlogs.php
@@ -35,6 +35,37 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Bots (single-bot by default, multi-bot when you need it)
+    |--------------------------------------------------------------------------
+    |
+    | By default this package runs with ONE bot: the 'default' token below is
+    | used for logs, direct messages, the support ticketing bot AND the web
+    | chat widget. You don't need to touch anything to stay single-bot.
+    |
+    | If you'd rather separate responsibilities — e.g. a quiet "logs" bot and a
+    | customer-facing "support" bot — just give the role its own token. Any role
+    | left empty automatically falls back to the 'default' bot.
+    |
+    |   default → logs channel, TelegramMessage, activity log
+    |   support → support ticket bot + web chat widget
+    |
+    | You may add custom roles here too; resolve them with:
+    |   Uzhlaravel\Telegramlogs\BotRegistry::token('your-role')
+    |
+    */
+    'bots' => [
+        'default' => [
+            'token' => env('TELEGRAM_BOT_TOKEN'),
+        ],
+
+        // Leave empty to reuse the default bot for support.
+        'support' => [
+            'token' => env('TELEGRAM_SUPPORT_BOT_TOKEN'),
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Telegram Topic ID
     |--------------------------------------------------------------------------
     |
@@ -245,14 +276,17 @@ return [
 
         /*
         |----------------------------------------------------------------------
-        | Support Bot Token
+        | Support Bot Token (legacy alias)
         |----------------------------------------------------------------------
         |
-        | Token for the support bot. Can be the same bot as the log bot or
-        | a dedicated one — a separate bot is recommended for clarity.
+        | Token resolution now lives in the 'bots' section above and is handled
+        | by Uzhlaravel\Telegramlogs\BotRegistry, which falls back to the
+        | default bot automatically. This key is kept as a legacy alias for
+        | backward compatibility and is only read when 'bots.support.token'
+        | is empty.
         |
         */
-        'bot_token' => env('TELEGRAM_SUPPORT_BOT_TOKEN', env('TELEGRAM_BOT_TOKEN')),
+        'bot_token' => env('TELEGRAM_SUPPORT_BOT_TOKEN'),
 
         /*
         |----------------------------------------------------------------------

--- a/config/telegramlogs.php
+++ b/config/telegramlogs.php
@@ -379,12 +379,12 @@ return [
         |----------------------------------------------------------------------
         */
         'widget' => [
-            'title'           => env('TELEGRAM_WEBCHAT_TITLE', 'Support'),
-            'subtitle'        => env('TELEGRAM_WEBCHAT_SUBTITLE', 'Nous répondons rapidement'),
-            'color'           => env('TELEGRAM_WEBCHAT_COLOR', '#0088CC'),
-            'placeholder'     => env('TELEGRAM_WEBCHAT_PLACEHOLDER', 'Votre message...'),
+            'title' => env('TELEGRAM_WEBCHAT_TITLE', 'Support'),
+            'subtitle' => env('TELEGRAM_WEBCHAT_SUBTITLE', 'Nous répondons rapidement'),
+            'color' => env('TELEGRAM_WEBCHAT_COLOR', '#0088CC'),
+            'placeholder' => env('TELEGRAM_WEBCHAT_PLACEHOLDER', 'Votre message...'),
             'welcome_message' => env('TELEGRAM_WEBCHAT_WELCOME', 'Bonjour ! Comment pouvons-nous vous aider ?'),
-            'require_name'    => env('TELEGRAM_WEBCHAT_REQUIRE_NAME', false),
+            'require_name' => env('TELEGRAM_WEBCHAT_REQUIRE_NAME', false),
         ],
 
         /*

--- a/config/telegramlogs.php
+++ b/config/telegramlogs.php
@@ -304,6 +304,67 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Web Chat Widget (no Telegram account needed for users)
+    |--------------------------------------------------------------------------
+    |
+    | Embeds a floating chat widget on your website. Users write in the widget,
+    | messages are tunnelled to the same Telegram staff group, and agent replies
+    | appear in the widget in real time (via polling).
+    |
+    | Inclusion in your Blade layout (before </body>):
+    |   @include('telegramlogs::webchat-widget')
+    |
+    | OR embed via a single <script> tag:
+    |   <script src="/telegram-support/widget.js"></script>
+    |
+    | Setup: php artisan telegram:support setup
+    |
+    */
+    'web_chat' => [
+
+        /*
+        |----------------------------------------------------------------------
+        | Max Upload Size (MB)
+        |----------------------------------------------------------------------
+        */
+        'max_upload_mb' => env('TELEGRAM_WEBCHAT_MAX_UPLOAD_MB', 20),
+
+        /*
+        |----------------------------------------------------------------------
+        | Poll Interval (ms)
+        |----------------------------------------------------------------------
+        |
+        | How often the widget checks for new messages from agents.
+        |
+        */
+        'poll_interval_ms' => env('TELEGRAM_WEBCHAT_POLL_MS', 3000),
+
+        /*
+        |----------------------------------------------------------------------
+        | Widget Appearance & Behaviour
+        |----------------------------------------------------------------------
+        */
+        'widget' => [
+            'title'           => env('TELEGRAM_WEBCHAT_TITLE', 'Support'),
+            'subtitle'        => env('TELEGRAM_WEBCHAT_SUBTITLE', 'Nous répondons rapidement'),
+            'color'           => env('TELEGRAM_WEBCHAT_COLOR', '#0088CC'),
+            'placeholder'     => env('TELEGRAM_WEBCHAT_PLACEHOLDER', 'Votre message...'),
+            'welcome_message' => env('TELEGRAM_WEBCHAT_WELCOME', 'Bonjour ! Comment pouvons-nous vous aider ?'),
+            'require_name'    => env('TELEGRAM_WEBCHAT_REQUIRE_NAME', false),
+        ],
+
+        /*
+        |----------------------------------------------------------------------
+        | Custom Messages
+        |----------------------------------------------------------------------
+        */
+        'messages' => [
+            'session_closed' => env('TELEGRAM_WEBCHAT_MSG_CLOSED'),
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Logging Channels Configuration
     |--------------------------------------------------------------------------
     |

--- a/database/migrations/create_support_tickets_table.php.stub
+++ b/database/migrations/create_support_tickets_table.php.stub
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('support_tickets', function (Blueprint $table): void {
+            $table->id();
+            $table->unsignedSmallInteger('ticket_number')->unique();
+            $table->unsignedBigInteger('user_telegram_id');
+            $table->string('username')->nullable();
+            $table->string('first_name');
+            $table->string('last_name')->nullable();
+            $table->enum('status', ['open', 'in_progress', 'closed'])->default('open');
+            $table->unsignedBigInteger('group_message_id')->nullable();
+            $table->timestamp('last_activity_at')->nullable();
+            $table->timestamp('closed_at')->nullable();
+            $table->timestamps();
+
+            $table->index('user_telegram_id');
+            $table->index(['user_telegram_id', 'status']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('support_tickets');
+    }
+};

--- a/database/migrations/create_ticket_messages_table.php.stub
+++ b/database/migrations/create_ticket_messages_table.php.stub
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('ticket_messages', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('ticket_id')->constrained('support_tickets')->cascadeOnDelete();
+            $table->enum('direction', ['user_to_agent', 'agent_to_user']);
+            $table->string('agent_name')->nullable();
+            $table->text('message_text')->nullable();
+            $table->string('media_type')->nullable(); // photo, document, video, audio, voice, sticker, video_note
+            $table->string('media_file_id', 512)->nullable();
+            $table->text('media_caption')->nullable();
+            $table->string('media_file_name')->nullable();
+            $table->unsignedBigInteger('telegram_message_id')->nullable(); // message ID in user private chat
+            $table->unsignedBigInteger('group_message_id')->nullable();    // message ID in staff group
+            $table->timestamps();
+
+            $table->index('ticket_id');
+            $table->index('group_message_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('ticket_messages');
+    }
+};

--- a/database/migrations/create_web_chat_messages_table.php.stub
+++ b/database/migrations/create_web_chat_messages_table.php.stub
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('web_chat_messages', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('session_id')->constrained('web_chat_sessions')->cascadeOnDelete();
+            $table->enum('direction', ['user_to_agent', 'agent_to_user']);
+            $table->text('content')->nullable();         // text content
+            $table->string('agent_name')->nullable();    // set when direction=agent_to_user
+            $table->string('media_path')->nullable();    // stored file (user uploads)
+            $table->string('media_name')->nullable();    // original filename
+            $table->string('media_mime', 100)->nullable();
+            $table->unsignedInteger('media_size')->nullable();
+            $table->string('media_file_id', 512)->nullable(); // Telegram file_id (agent files)
+            $table->unsignedBigInteger('group_message_id')->nullable(); // for agent-reply lookup
+            $table->timestamp('read_at')->nullable();
+            $table->timestamps();
+
+            $table->index('session_id');
+            $table->index('group_message_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('web_chat_messages');
+    }
+};

--- a/database/migrations/create_web_chat_sessions_table.php.stub
+++ b/database/migrations/create_web_chat_sessions_table.php.stub
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('web_chat_sessions', function (Blueprint $table): void {
+            $table->id();
+            $table->uuid('session_token')->unique();   // stored in browser localStorage
+            $table->string('display_name')->nullable();
+            $table->string('email')->nullable();
+            $table->enum('status', ['open', 'in_progress', 'closed'])->default('open');
+            $table->unsignedBigInteger('group_message_id')->nullable(); // Telegram group anchor
+            $table->timestamp('last_activity_at')->nullable();
+            $table->timestamp('closed_at')->nullable();
+            $table->timestamps();
+
+            $table->index('session_token');
+            $table->index('status');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('web_chat_sessions');
+    }
+};

--- a/resources/views/webchat-widget.blade.php
+++ b/resources/views/webchat-widget.blade.php
@@ -1,0 +1,578 @@
+{{-- Telegram Web Chat Widget --}}
+{{-- Include before </body>: @include('telegramlogs::webchat-widget') --}}
+{{-- Or via JS: <script src="/telegram-support/widget.js"></script> --}}
+
+@php
+$configJson = $configJson ?? json_encode([
+    'baseUrl'        => rtrim(config('app.url', ''), '/') . '/telegram-support/chat',
+    'title'          => config('telegramlogs.web_chat.widget.title', 'Support'),
+    'subtitle'       => config('telegramlogs.web_chat.widget.subtitle', 'Nous répondons rapidement'),
+    'color'          => config('telegramlogs.web_chat.widget.color', '#0088CC'),
+    'requireName'    => config('telegramlogs.web_chat.widget.require_name', false),
+    'placeholder'    => config('telegramlogs.web_chat.widget.placeholder', 'Votre message...'),
+    'welcomeMessage' => config('telegramlogs.web_chat.widget.welcome_message', 'Bonjour ! Comment pouvons-nous vous aider ?'),
+    'pollInterval'   => (int) config('telegramlogs.web_chat.poll_interval_ms', 3000),
+]);
+@endphp
+
+<div id="tgw-root">
+
+<style>
+:root{--tgw-c:{{ config('telegramlogs.web_chat.widget.color','#0088CC') }}}
+#tgw-root *{box-sizing:border-box;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif}
+#tgw-btn{position:fixed;bottom:24px;right:24px;z-index:9998;width:56px;height:56px;border-radius:50%;background:var(--tgw-c);border:none;cursor:pointer;box-shadow:0 4px 16px rgba(0,0,0,.25);display:flex;align-items:center;justify-content:center;transition:transform .2s,box-shadow .2s}
+#tgw-btn:hover{transform:scale(1.08);box-shadow:0 6px 20px rgba(0,0,0,.3)}
+#tgw-btn svg{width:28px;height:28px;fill:#fff}
+#tgw-badge{position:absolute;top:-4px;right:-4px;background:#e74c3c;color:#fff;font-size:11px;font-weight:700;border-radius:50%;min-width:18px;height:18px;display:none;align-items:center;justify-content:center;padding:0 4px}
+
+#tgw-win{position:fixed;bottom:92px;right:24px;z-index:9999;width:360px;max-width:calc(100vw - 32px);height:520px;max-height:calc(100vh - 110px);background:#fff;border-radius:16px;box-shadow:0 8px 40px rgba(0,0,0,.2);display:flex;flex-direction:column;overflow:hidden;transform:scale(.85) translateY(20px);opacity:0;pointer-events:none;transition:transform .25s cubic-bezier(.34,1.56,.64,1),opacity .2s}
+#tgw-win.open{transform:scale(1) translateY(0);opacity:1;pointer-events:all}
+
+/* Header */
+#tgw-head{background:var(--tgw-c);padding:14px 16px;display:flex;align-items:center;gap:10px;flex-shrink:0}
+#tgw-head-avatar{width:38px;height:38px;border-radius:50%;background:rgba(255,255,255,.25);display:flex;align-items:center;justify-content:center;flex-shrink:0}
+#tgw-head-avatar svg{width:22px;height:22px;fill:#fff}
+#tgw-head-info{flex:1;min-width:0}
+#tgw-head-title{color:#fff;font-size:15px;font-weight:600;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+#tgw-head-sub{color:rgba(255,255,255,.8);font-size:12px;margin-top:1px}
+#tgw-close{background:none;border:none;cursor:pointer;color:rgba(255,255,255,.8);padding:4px;border-radius:50%;display:flex;transition:background .15s}
+#tgw-close:hover{background:rgba(255,255,255,.2);color:#fff}
+#tgw-close svg{width:18px;height:18px;fill:currentColor}
+
+/* Body */
+#tgw-body{flex:1;overflow-y:auto;padding:14px 12px;display:flex;flex-direction:column;gap:8px;background:#f5f7fa;scroll-behavior:smooth}
+#tgw-body::-webkit-scrollbar{width:4px}
+#tgw-body::-webkit-scrollbar-thumb{background:#ccc;border-radius:2px}
+
+/* Name prompt */
+#tgw-name-form{background:#fff;border-radius:12px;padding:20px;text-align:center;box-shadow:0 1px 4px rgba(0,0,0,.08)}
+#tgw-name-form h3{margin:0 0 6px;font-size:15px;color:#222}
+#tgw-name-form p{margin:0 0 14px;font-size:13px;color:#666}
+#tgw-name-input{width:100%;padding:9px 12px;border:1.5px solid #e0e0e0;border-radius:8px;font-size:14px;outline:none;transition:border .15s}
+#tgw-name-input:focus{border-color:var(--tgw-c)}
+#tgw-name-btn{margin-top:10px;width:100%;padding:10px;background:var(--tgw-c);color:#fff;border:none;border-radius:8px;font-size:14px;font-weight:600;cursor:pointer;transition:opacity .15s}
+#tgw-name-btn:hover{opacity:.9}
+
+/* Welcome bubble */
+.tgw-welcome{background:#fff;border-radius:12px;padding:12px 14px;font-size:13.5px;color:#444;line-height:1.5;box-shadow:0 1px 4px rgba(0,0,0,.06);max-width:85%}
+
+/* Messages */
+.tgw-msg{display:flex;flex-direction:column;max-width:80%}
+.tgw-msg.user{align-self:flex-end;align-items:flex-end}
+.tgw-msg.agent{align-self:flex-start;align-items:flex-start}
+.tgw-bubble{padding:9px 13px;border-radius:16px;font-size:14px;line-height:1.45;word-break:break-word}
+.tgw-msg.user .tgw-bubble{background:var(--tgw-c);color:#fff;border-bottom-right-radius:4px}
+.tgw-msg.agent .tgw-bubble{background:#fff;color:#222;border-bottom-left-radius:4px;box-shadow:0 1px 3px rgba(0,0,0,.08)}
+.tgw-agent-name{font-size:11px;color:#888;margin-bottom:3px;padding-left:2px}
+.tgw-time{font-size:11px;color:#aaa;margin-top:3px;padding:0 2px}
+.tgw-msg.user .tgw-time{text-align:right}
+
+/* File message */
+.tgw-file{display:flex;align-items:center;gap:8px;text-decoration:none;color:inherit}
+.tgw-file-icon{width:32px;height:32px;flex-shrink:0;opacity:.85}
+.tgw-msg.user .tgw-file-icon{filter:brightness(10)}
+.tgw-file-info{min-width:0}
+.tgw-file-name{font-size:13px;font-weight:500;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:160px}
+.tgw-file-size{font-size:11px;opacity:.7}
+
+/* Image message */
+.tgw-img{max-width:200px;border-radius:10px;display:block;cursor:zoom-in}
+
+/* Typing indicator */
+#tgw-typing{align-self:flex-start;display:none}
+#tgw-typing .tgw-bubble{display:flex;gap:4px;align-items:center;padding:10px 14px}
+#tgw-typing span{width:7px;height:7px;background:#bbb;border-radius:50%;animation:tgw-dot 1.2s infinite}
+#tgw-typing span:nth-child(2){animation-delay:.2s}
+#tgw-typing span:nth-child(3){animation-delay:.4s}
+@keyframes tgw-dot{0%,60%,100%{transform:translateY(0)}30%{transform:translateY(-5px)}}
+
+/* Closed banner */
+#tgw-closed{background:#f0f0f0;border-radius:8px;padding:10px 14px;font-size:12.5px;color:#666;text-align:center;flex-shrink:0;margin:6px 0}
+
+/* Footer */
+#tgw-footer{padding:10px 10px 10px;background:#fff;border-top:1px solid #eee;flex-shrink:0}
+#tgw-input-row{display:flex;gap:8px;align-items:flex-end}
+#tgw-upload-btn{background:none;border:none;cursor:pointer;color:#aaa;padding:6px;border-radius:8px;display:flex;flex-shrink:0;transition:color .15s,background .15s}
+#tgw-upload-btn:hover{color:var(--tgw-c);background:#f0f5ff}
+#tgw-upload-btn svg{width:20px;height:20px;fill:currentColor}
+#tgw-upload-input{display:none}
+#tgw-textarea{flex:1;border:1.5px solid #e5e5e5;border-radius:10px;padding:8px 12px;font-size:14px;resize:none;outline:none;max-height:120px;line-height:1.4;transition:border .15s;font-family:inherit}
+#tgw-textarea:focus{border-color:var(--tgw-c)}
+#tgw-send-btn{background:var(--tgw-c);border:none;cursor:pointer;border-radius:10px;width:38px;height:38px;display:flex;align-items:center;justify-content:center;flex-shrink:0;transition:opacity .15s}
+#tgw-send-btn:hover{opacity:.85}
+#tgw-send-btn svg{width:18px;height:18px;fill:#fff}
+#tgw-send-btn:disabled{opacity:.4;cursor:default}
+#tgw-upload-bar{margin-top:6px;font-size:12px;color:#888;display:none;align-items:center;gap:6px}
+#tgw-upload-progress{flex:1;height:3px;background:#eee;border-radius:2px;overflow:hidden}
+#tgw-upload-fill{height:100%;background:var(--tgw-c);width:0%;transition:width .3s}
+</style>
+
+<!-- Floating button -->
+<button id="tgw-btn" aria-label="Ouvrir le chat support">
+  <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+    <path d="M20 2H4C2.9 2 2 2.9 2 4v18l4-4h14c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm-2 12H6v-2h12v2zm0-3H6V9h12v2zm0-3H6V6h12v2z"/>
+  </svg>
+  <span id="tgw-badge"></span>
+</button>
+
+<!-- Chat window -->
+<div id="tgw-win" role="dialog" aria-label="Chat support">
+  <div id="tgw-head">
+    <div id="tgw-head-avatar">
+      <svg viewBox="0 0 24 24"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z"/></svg>
+    </div>
+    <div id="tgw-head-info">
+      <div id="tgw-head-title">Support</div>
+      <div id="tgw-head-sub">Nous répondons rapidement</div>
+    </div>
+    <button id="tgw-close" aria-label="Fermer">
+      <svg viewBox="0 0 24 24"><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/></svg>
+    </button>
+  </div>
+
+  <div id="tgw-body">
+    <!-- Messages rendered here by JS -->
+  </div>
+
+  <div id="tgw-footer">
+    <div id="tgw-input-row">
+      <button id="tgw-upload-btn" title="Joindre un fichier" type="button">
+        <svg viewBox="0 0 24 24"><path d="M16.5 6v11.5c0 2.21-1.79 4-4 4s-4-1.79-4-4V5a2.5 2.5 0 0 1 5 0v10.5c0 .83-.67 1.5-1.5 1.5s-1.5-.67-1.5-1.5V6H9v9.5a3 3 0 0 0 6 0V5c0-2.21-1.79-4-4-4S7 2.79 7 5v12.5c0 3.04 2.46 5.5 5.5 5.5s5.5-2.46 5.5-5.5V6h-1.5z"/></svg>
+      </button>
+      <input id="tgw-upload-input" type="file" accept="*/*">
+      <textarea id="tgw-textarea" rows="1" placeholder="Votre message..."></textarea>
+      <button id="tgw-send-btn" type="button" disabled aria-label="Envoyer">
+        <svg viewBox="0 0 24 24"><path d="M2.01 21L23 12 2.01 3 2 10l15 2-15 2z"/></svg>
+      </button>
+    </div>
+    <div id="tgw-upload-bar">
+      <span id="tgw-upload-name"></span>
+      <div id="tgw-upload-progress"><div id="tgw-upload-fill"></div></div>
+    </div>
+  </div>
+</div>
+
+</div>{{-- #tgw-root --}}
+
+<script>
+(function() {
+  'use strict';
+
+  var CFG = {!! $configJson !!};
+
+  /* ── DOM refs ─────────────────────────────────────────────────── */
+  var btn       = document.getElementById('tgw-btn');
+  var badge     = document.getElementById('tgw-badge');
+  var win       = document.getElementById('tgw-win');
+  var body      = document.getElementById('tgw-body');
+  var closeBtn  = document.getElementById('tgw-close');
+  var textarea  = document.getElementById('tgw-textarea');
+  var sendBtn   = document.getElementById('tgw-send-btn');
+  var uploadBtn = document.getElementById('tgw-upload-btn');
+  var uploadInp = document.getElementById('tgw-upload-input');
+  var uploadBar = document.getElementById('tgw-upload-bar');
+  var uploadNm  = document.getElementById('tgw-upload-name');
+  var uploadFl  = document.getElementById('tgw-upload-fill');
+  var headTitle = document.getElementById('tgw-head-title');
+  var headSub   = document.getElementById('tgw-head-sub');
+
+  /* ── State ────────────────────────────────────────────────────── */
+  var state = {
+    token:       localStorage.getItem('tgw_token'),
+    lastId:      0,
+    isOpen:      false,
+    sessionStatus: 'open',
+    unread:      0,
+    pollTimer:   null,
+    initialized: false,
+    nameRequired: CFG.requireName && !localStorage.getItem('tgw_name_set'),
+  };
+
+  /* ── Apply config ─────────────────────────────────────────────── */
+  headTitle.textContent = CFG.title;
+  headSub.textContent   = CFG.subtitle;
+  textarea.placeholder  = CFG.placeholder;
+  document.getElementById('tgw-root').style.setProperty('--tgw-c-runtime', CFG.color);
+
+  /* ── Helpers ──────────────────────────────────────────────────── */
+  function csrfToken() {
+    var m = document.querySelector('meta[name="csrf-token"]');
+    return m ? m.content : '';
+  }
+
+  function api(path, opts) {
+    var url = CFG.baseUrl + path;
+    var headers = { 'Content-Type': 'application/json', 'Accept': 'application/json' };
+    if (state.token) headers['X-Chat-Token'] = state.token;
+    var csrf = csrfToken();
+    if (csrf) headers['X-CSRF-TOKEN'] = csrf;
+    return fetch(url, Object.assign({ headers: headers }, opts));
+  }
+
+  function formatTime(iso) {
+    var d = new Date(iso);
+    return d.getHours().toString().padStart(2,'0') + ':' + d.getMinutes().toString().padStart(2,'0');
+  }
+
+  function formatSize(bytes) {
+    if (!bytes) return '';
+    if (bytes < 1024) return bytes + ' o';
+    if (bytes < 1048576) return (bytes/1024).toFixed(1) + ' Ko';
+    return (bytes/1048576).toFixed(1) + ' Mo';
+  }
+
+  function scrollBottom() {
+    body.scrollTop = body.scrollHeight;
+  }
+
+  function setBadge(n) {
+    state.unread = n;
+    badge.textContent = n > 9 ? '9+' : n;
+    badge.style.display = n > 0 ? 'flex' : 'none';
+  }
+
+  /* ── Render messages ──────────────────────────────────────────── */
+  function renderMessage(m) {
+    var isUser  = m.direction === 'user_to_agent';
+    var wrapper = document.createElement('div');
+    wrapper.className = 'tgw-msg ' + (isUser ? 'user' : 'agent');
+    wrapper.dataset.id = m.id;
+
+    if (!isUser && m.agent_name) {
+      var nameEl = document.createElement('div');
+      nameEl.className = 'tgw-agent-name';
+      nameEl.textContent = m.agent_name;
+      wrapper.appendChild(nameEl);
+    }
+
+    var bubble = document.createElement('div');
+    bubble.className = 'tgw-bubble';
+
+    if (m.file) {
+      var isImg = m.file.mime && m.file.mime.startsWith('image/');
+      if (isImg) {
+        var img = document.createElement('img');
+        img.src = m.file.url + '?t=' + state.token;
+        img.className = 'tgw-img';
+        img.alt = m.file.name;
+        img.onclick = function() { window.open(this.src, '_blank'); };
+        bubble.appendChild(img);
+      } else {
+        var link = document.createElement('a');
+        link.href = m.file.url + '?session_token=' + encodeURIComponent(state.token);
+        link.target = '_blank';
+        link.className = 'tgw-file';
+        link.innerHTML =
+          '<svg class="tgw-file-icon" viewBox="0 0 24 24"><path d="M6 2c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V8l-6-6H6zm7 7V3.5L18.5 9H13z"/></svg>' +
+          '<div class="tgw-file-info"><div class="tgw-file-name">' + escHtml(m.file.name) + '</div>' +
+          '<div class="tgw-file-size">' + formatSize(m.file.size) + ' — Télécharger</div></div>';
+        bubble.appendChild(link);
+      }
+      if (m.content) {
+        var caption = document.createElement('div');
+        caption.style.marginTop = '6px';
+        caption.style.fontSize = '13px';
+        caption.textContent = m.content;
+        bubble.appendChild(caption);
+      }
+    } else {
+      bubble.textContent = m.content || '';
+    }
+
+    wrapper.appendChild(bubble);
+
+    var timeEl = document.createElement('div');
+    timeEl.className = 'tgw-time';
+    timeEl.textContent = formatTime(m.created_at);
+    wrapper.appendChild(timeEl);
+
+    body.appendChild(wrapper);
+    return wrapper;
+  }
+
+  function escHtml(s) {
+    return (s || '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+  }
+
+  function renderWelcome() {
+    var el = document.createElement('div');
+    el.className = 'tgw-welcome';
+    el.textContent = CFG.welcomeMessage;
+    body.appendChild(el);
+  }
+
+  function renderClosed() {
+    if (document.getElementById('tgw-closed')) return;
+    var el = document.createElement('div');
+    el.id = 'tgw-closed';
+    el.textContent = 'Cette session est fermée. Actualisez la page pour en ouvrir une nouvelle.';
+    document.getElementById('tgw-footer').prepend(el);
+    textarea.disabled = true;
+    sendBtn.disabled  = true;
+    uploadBtn.disabled = true;
+  }
+
+  /* ── Name prompt ──────────────────────────────────────────────── */
+  function showNamePrompt() {
+    var form = document.createElement('div');
+    form.id = 'tgw-name-form';
+    form.innerHTML =
+      '<h3>Avant de commencer</h3>' +
+      '<p>Comment souhaitez-vous être appelé ?</p>' +
+      '<input id="tgw-name-input" type="text" placeholder="Votre prénom (optionnel)" maxlength="80">' +
+      '<button id="tgw-name-btn" type="button">Démarrer la conversation</button>';
+    body.appendChild(form);
+
+    document.getElementById('tgw-name-btn').onclick = function() {
+      var name = (document.getElementById('tgw-name-input').value || '').trim();
+      localStorage.setItem('tgw_name_set', '1');
+      startSession(name || null);
+      form.remove();
+    };
+    document.getElementById('tgw-name-input').onkeydown = function(e) {
+      if (e.key === 'Enter') document.getElementById('tgw-name-btn').click();
+    };
+  }
+
+  /* ── Session ──────────────────────────────────────────────────── */
+  function startSession(name) {
+    api('/start', {
+      method: 'POST',
+      body: JSON.stringify({ session_token: state.token, name: name }),
+    })
+    .then(function(r) { return r.json(); })
+    .then(function(data) {
+      if (data.session_token) {
+        state.token = data.session_token;
+        localStorage.setItem('tgw_token', state.token);
+        state.sessionStatus = data.status || 'open';
+        state.initialized   = true;
+        if (!data.resumed) renderWelcome();
+        startPolling();
+      }
+    })
+    .catch(function(e) { console.error('[TGW] start failed', e); });
+  }
+
+  /* ── Polling ──────────────────────────────────────────────────── */
+  function startPolling() {
+    pollMessages();
+    state.pollTimer = setInterval(pollMessages, CFG.pollInterval);
+  }
+
+  function stopPolling() {
+    clearInterval(state.pollTimer);
+    state.pollTimer = null;
+  }
+
+  function pollMessages() {
+    if (!state.token) return;
+
+    api('/messages?session_token=' + encodeURIComponent(state.token) + '&after=' + state.lastId)
+    .then(function(r) { return r.json(); })
+    .then(function(data) {
+      if (!data.messages) return;
+
+      var newAgent = 0;
+      data.messages.forEach(function(m) {
+        if (m.id > state.lastId) {
+          state.lastId = m.id;
+          renderMessage(m);
+          if (m.direction === 'agent_to_user' && !state.isOpen) newAgent++;
+        }
+      });
+
+      if (newAgent > 0) setBadge(state.unread + newAgent);
+
+      state.sessionStatus = data.status || state.sessionStatus;
+      if (data.status === 'closed') {
+        stopPolling();
+        renderClosed();
+      }
+
+      scrollBottom();
+    })
+    .catch(function() {});
+  }
+
+  /* ── Send text ────────────────────────────────────────────────── */
+  function sendMessage() {
+    var text = textarea.value.trim();
+    if (!text || !state.token) return;
+
+    // Optimistic render
+    var now = new Date().toISOString();
+    renderMessage({ id: 'p' + Date.now(), direction: 'user_to_agent', content: text, created_at: now });
+    scrollBottom();
+
+    textarea.value = '';
+    autoGrow();
+    sendBtn.disabled = true;
+
+    api('/send', {
+      method: 'POST',
+      body: JSON.stringify({ session_token: state.token, message: text }),
+    })
+    .then(function(r) { return r.json(); })
+    .then(function(data) {
+      if (data.error) console.warn('[TGW] send error:', data.error);
+    })
+    .catch(function(e) { console.error('[TGW] send failed', e); });
+  }
+
+  /* ── Upload file ──────────────────────────────────────────────── */
+  uploadBtn.onclick = function() { uploadInp.click(); };
+
+  uploadInp.onchange = function() {
+    var file = uploadInp.files[0];
+    if (!file || !state.token) return;
+
+    var maxMb = {{ (int) config('telegramlogs.web_chat.max_upload_mb', 20) }};
+    if (file.size > maxMb * 1024 * 1024) {
+      alert('Fichier trop volumineux (max ' + maxMb + ' Mo).');
+      uploadInp.value = '';
+      return;
+    }
+
+    uploadBar.style.display = 'flex';
+    uploadNm.textContent = file.name;
+    uploadFl.style.width = '0%';
+
+    var fd = new FormData();
+    fd.append('file', file);
+    fd.append('session_token', state.token);
+
+    var xhr = new XMLHttpRequest();
+    xhr.open('POST', CFG.baseUrl + '/upload');
+    xhr.setRequestHeader('X-Chat-Token', state.token);
+    xhr.setRequestHeader('Accept', 'application/json');
+    var csrf = csrfToken();
+    if (csrf) xhr.setRequestHeader('X-CSRF-TOKEN', csrf);
+
+    xhr.upload.onprogress = function(e) {
+      if (e.lengthComputable) {
+        uploadFl.style.width = Math.round(e.loaded / e.total * 100) + '%';
+      }
+    };
+
+    xhr.onload = function() {
+      uploadBar.style.display = 'none';
+      uploadFl.style.width = '0%';
+      uploadInp.value = '';
+
+      if (xhr.status === 201) {
+        var data = JSON.parse(xhr.responseText);
+        renderMessage({
+          id: 'f' + Date.now(),
+          direction: 'user_to_agent',
+          content: null,
+          created_at: new Date().toISOString(),
+          file: { name: data.name, size: data.size, mime: '', url: '' },
+        });
+        scrollBottom();
+      } else {
+        try {
+          var err = JSON.parse(xhr.responseText);
+          alert(err.error || 'Erreur lors de l\'envoi du fichier.');
+        } catch(e) {
+          alert('Erreur lors de l\'envoi du fichier.');
+        }
+      }
+    };
+
+    xhr.onerror = function() {
+      uploadBar.style.display = 'none';
+      alert('Erreur réseau lors de l\'envoi du fichier.');
+    };
+
+    xhr.send(fd);
+  };
+
+  /* ── Textarea auto-grow ───────────────────────────────────────── */
+  function autoGrow() {
+    textarea.style.height = 'auto';
+    textarea.style.height = Math.min(textarea.scrollHeight, 120) + 'px';
+  }
+
+  textarea.oninput = function() {
+    autoGrow();
+    sendBtn.disabled = textarea.value.trim() === '';
+  };
+
+  textarea.onkeydown = function(e) {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      if (!sendBtn.disabled) sendMessage();
+    }
+  };
+
+  sendBtn.onclick = sendMessage;
+
+  /* ── Open / Close ─────────────────────────────────────────────── */
+  function openWidget() {
+    state.isOpen = true;
+    win.classList.add('open');
+    setBadge(0);
+
+    if (!state.initialized) {
+      if (CFG.requireName && state.nameRequired) {
+        showNamePrompt();
+      } else {
+        startSession(null);
+      }
+    }
+
+    if (state.initialized && !state.pollTimer && state.sessionStatus !== 'closed') {
+      startPolling();
+    }
+
+    scrollBottom();
+    setTimeout(function() { textarea.focus(); }, 250);
+  }
+
+  function closeWidget() {
+    state.isOpen = false;
+    win.classList.remove('open');
+    // Keep polling in background for unread badge
+  }
+
+  btn.onclick   = function() { state.isOpen ? closeWidget() : openWidget(); };
+  closeBtn.onclick = closeWidget;
+
+  /* ── Keyboard (Escape) ────────────────────────────────────────── */
+  document.addEventListener('keydown', function(e) {
+    if (e.key === 'Escape' && state.isOpen) closeWidget();
+  });
+
+  /* ── Bootstrap: if token exists, start background polling ──── */
+  if (state.token) {
+    // Validate existing token silently
+    api('/messages?session_token=' + encodeURIComponent(state.token) + '&after=0')
+    .then(function(r) {
+      if (r.status === 401) {
+        localStorage.removeItem('tgw_token');
+        state.token = null;
+        return null;
+      }
+      return r.json();
+    })
+    .then(function(data) {
+      if (!data) return;
+      state.initialized = true;
+      state.sessionStatus = data.status;
+      // Count unread agent messages
+      var unread = 0;
+      data.messages.forEach(function(m) {
+        if (m.id > state.lastId) state.lastId = m.id;
+        if (m.direction === 'agent_to_user') unread++;
+      });
+      if (unread > 0) setBadge(unread);
+      if (data.status !== 'closed') {
+        state.pollTimer = setInterval(pollMessages, CFG.pollInterval);
+      }
+    })
+    .catch(function() {});
+  }
+
+})();
+</script>

--- a/routes/support.php
+++ b/routes/support.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Route;
+use Uzhlaravel\Telegramlogs\Support\SupportWebhookController;
+
+Route::post(
+    config('telegramlogs.support_bot.webhook_path', '/telegram/support/webhook'),
+    SupportWebhookController::class
+)->name('telegram.support.webhook');

--- a/routes/webchat.php
+++ b/routes/webchat.php
@@ -22,10 +22,10 @@ use Uzhlaravel\Telegramlogs\WebChat\WebChatController;
 */
 
 Route::prefix('telegram-support')->group(function (): void {
-    Route::post('/chat/start',   [WebChatController::class, 'start'])->name('telegram.webchat.start');
-    Route::post('/chat/send',    [WebChatController::class, 'send'])->name('telegram.webchat.send');
-    Route::post('/chat/upload',  [WebChatController::class, 'upload'])->name('telegram.webchat.upload');
+    Route::post('/chat/start', [WebChatController::class, 'start'])->name('telegram.webchat.start');
+    Route::post('/chat/send', [WebChatController::class, 'send'])->name('telegram.webchat.send');
+    Route::post('/chat/upload', [WebChatController::class, 'upload'])->name('telegram.webchat.upload');
     Route::get('/chat/messages', [WebChatController::class, 'messages'])->name('telegram.webchat.messages');
     Route::get('/chat/file/{id}', [WebChatController::class, 'downloadFile'])->name('telegram.webchat.file');
-    Route::get('/widget.js',     [WebChatController::class, 'widgetJs'])->name('telegram.webchat.js');
+    Route::get('/widget.js', [WebChatController::class, 'widgetJs'])->name('telegram.webchat.js');
 });

--- a/routes/webchat.php
+++ b/routes/webchat.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Route;
+use Uzhlaravel\Telegramlogs\WebChat\WebChatController;
+
+/*
+|--------------------------------------------------------------------------
+| Web Chat API Routes
+|--------------------------------------------------------------------------
+|
+| These routes are consumed by the embeddable chat widget.
+| Exclude them from CSRF in your middleware:
+|
+|   Laravel 11+ (bootstrap/app.php):
+|     ->withMiddleware(fn($m) => $m->validateCsrfTokens(except: ['/telegram-support/*']))
+|
+|   Laravel 10 (VerifyCsrfToken::$except):
+|     '/telegram-support/chat/*',
+|
+*/
+
+Route::prefix('telegram-support')->group(function (): void {
+    Route::post('/chat/start',   [WebChatController::class, 'start'])->name('telegram.webchat.start');
+    Route::post('/chat/send',    [WebChatController::class, 'send'])->name('telegram.webchat.send');
+    Route::post('/chat/upload',  [WebChatController::class, 'upload'])->name('telegram.webchat.upload');
+    Route::get('/chat/messages', [WebChatController::class, 'messages'])->name('telegram.webchat.messages');
+    Route::get('/chat/file/{id}', [WebChatController::class, 'downloadFile'])->name('telegram.webchat.file');
+    Route::get('/widget.js',     [WebChatController::class, 'widgetJs'])->name('telegram.webchat.js');
+});

--- a/src/BotRegistry.php
+++ b/src/BotRegistry.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Uzhlaravel\Telegramlogs;
+
+/**
+ * Central resolver for Telegram bot tokens by role.
+ *
+ * By default the package runs with a SINGLE bot: every role (logs, support,
+ * web chat) resolves to the same `TELEGRAM_BOT_TOKEN`.
+ *
+ * To split responsibilities across multiple bots, define a dedicated token
+ * for a role in config('telegramlogs.bots'). Any role without its own token
+ * transparently falls back to the default bot, so existing single-bot setups
+ * keep working with zero changes.
+ *
+ * Built-in roles:
+ *   - 'default' : log channel, direct messages, activity log
+ *   - 'support' : support ticket bot + web chat widget
+ *
+ * You may add as many custom roles as you like under config('telegramlogs.bots').
+ */
+final class BotRegistry
+{
+    /**
+     * Resolve the bot token for a given role, falling back to the default bot.
+     */
+    public static function token(string $role = 'default'): string
+    {
+        $token = config("telegramlogs.bots.{$role}.token");
+
+        // Legacy key support for the support bot.
+        if (empty($token) && $role === 'support') {
+            $token = config('telegramlogs.support_bot.bot_token');
+        }
+
+        // Any non-default role falls back to the default bot.
+        if (empty($token) && $role !== 'default') {
+            $token = self::resolveDefault();
+        }
+
+        if (empty($token)) {
+            $token = self::resolveDefault();
+        }
+
+        return (string) ($token ?? '');
+    }
+
+    /**
+     * Whether a token (its own or an inherited default) is available for a role.
+     */
+    public static function isConfigured(string $role = 'default'): bool
+    {
+        return self::token($role) !== '';
+    }
+
+    /**
+     * Whether this role has its OWN dedicated bot, distinct from the default.
+     * Returns false when the role merely inherits the default bot.
+     */
+    public static function hasDedicatedBot(string $role): bool
+    {
+        if ($role === 'default') {
+            return self::token('default') !== '';
+        }
+
+        $explicit = config("telegramlogs.bots.{$role}.token");
+
+        if (empty($explicit) && $role === 'support') {
+            $explicit = config('telegramlogs.support_bot.bot_token');
+        }
+
+        return ! empty($explicit) && $explicit !== self::resolveDefault();
+    }
+
+    /**
+     * List every role the package knows about (built-ins + custom).
+     *
+     * @return string[]
+     */
+    public static function roles(): array
+    {
+        $roles = array_keys((array) config('telegramlogs.bots', []));
+
+        foreach (['default', 'support'] as $builtin) {
+            if (! in_array($builtin, $roles, true)) {
+                $roles[] = $builtin;
+            }
+        }
+
+        return $roles;
+    }
+
+    /**
+     * Are we running in single-bot mode (no role has its own dedicated token)?
+     */
+    public static function isSingleBotMode(): bool
+    {
+        foreach (self::roles() as $role) {
+            if ($role !== 'default' && self::hasDedicatedBot($role)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static function resolveDefault(): string
+    {
+        return (string) (
+            config('telegramlogs.bots.default.token')
+            ?? config('telegramlogs.bot_token')
+            ?? ''
+        );
+    }
+}

--- a/src/Commands/SupportBotCommand.php
+++ b/src/Commands/SupportBotCommand.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Uzhlaravel\Telegramlogs\Commands;
+
+use Illuminate\Console\Command;
+use Uzhlaravel\Telegramlogs\Support\SupportBotHandler;
+use Uzhlaravel\Telegramlogs\Support\SupportTicket;
+
+final class SupportBotCommand extends Command
+{
+    protected $signature = 'telegram:support
+        {action : setup | webhook-set | webhook-delete | status | tickets}
+        {--url= : Webhook URL (for webhook-set)}
+        {--secret= : Webhook secret token (for webhook-set)}
+        {--limit=20 : Number of tickets to display (for tickets)}';
+
+    protected $description = 'Manage the Telegram Support Bot (ticketing tunnel)';
+
+    public function handle(): int
+    {
+        return match ($this->argument('action')) {
+            'setup' => $this->runSetup(),
+            'webhook-set' => $this->runWebhookSet(app(SupportBotHandler::class)),
+            'webhook-delete' => $this->runWebhookDelete(app(SupportBotHandler::class)),
+            'status' => $this->runStatus(app(SupportBotHandler::class)),
+            'tickets' => $this->runTickets(),
+            default => $this->unknownAction(),
+        };
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+
+    private function runSetup(): int
+    {
+        $this->components->info('Telegram Support Bot — Setup Guide');
+        $this->newLine();
+
+        $this->line('  <comment>Step 1 — Create the support bot:</comment>');
+        $this->line('  Chat with @BotFather on Telegram and run /newbot.');
+        $this->line('  Copy the token you receive.');
+        $this->newLine();
+
+        $this->line('  <comment>Step 2 — Create the staff group:</comment>');
+        $this->line('  Create a private Telegram group for your support agents.');
+        $this->line('  Add the bot to the group and grant it admin rights (so it can read replies).');
+        $this->newLine();
+
+        $this->line('  <comment>Step 3 — Get the group ID:</comment>');
+        $this->line('  Temporarily add @userinfobot to the group, note the group ID, then remove it.');
+        $this->line('  Group IDs for supergroups start with -100.');
+        $this->newLine();
+
+        $this->line('  <comment>Step 4 — Set environment variables:</comment>');
+        $this->newLine();
+        $this->line('  <info>Required:</info>');
+        $this->line('  TELEGRAM_SUPPORT_BOT_TOKEN=123456:ABC-your-bot-token');
+        $this->line('  TELEGRAM_SUPPORT_GROUP_ID=-100123456789');
+        $this->newLine();
+        $this->line('  <info>Recommended:</info>');
+        $this->line('  TELEGRAM_SUPPORT_WEBHOOK_SECRET=a-long-random-string');
+        $this->newLine();
+        $this->line('  <info>Optional:</info>');
+        $this->line('  TELEGRAM_SUPPORT_WEBHOOK_PATH=/telegram/support/webhook');
+        $this->newLine();
+
+        $this->line('  <comment>Step 5 — Publish and run migrations:</comment>');
+        $this->line('  php artisan vendor:publish --tag=telegramlogs-support-migrations');
+        $this->line('  php artisan migrate');
+        $this->newLine();
+
+        $this->line('  <comment>Step 6 — Register your webhook:</comment>');
+        $this->line('  php artisan telegram:support webhook-set --url=https://yourapp.com/telegram/support/webhook');
+        $this->newLine();
+
+        $this->line('  <comment>Agent commands (reply in the staff group):</comment>');
+        $this->line('  /status  — show ticket details');
+        $this->line('  /close   — close and resolve the ticket');
+        $this->newLine();
+
+        $this->components->success('Done! Follow the steps above to get your support bot running.');
+
+        return self::SUCCESS;
+    }
+
+    private function runWebhookSet(SupportBotHandler $handler): int
+    {
+        $url = $this->option('url')
+            ?? $this->ask('Webhook URL (e.g. https://yourapp.com/telegram/support/webhook)');
+
+        if (! $url) {
+            $this->components->error('Webhook URL is required.');
+
+            return self::FAILURE;
+        }
+
+        $secret = $this->option('secret')
+            ?? config('telegramlogs.support_bot.webhook_secret');
+
+        $this->components->info("Setting webhook → {$url}");
+
+        $result = $handler->setWebhook($url, $secret ?: null);
+
+        if ($result['ok'] ?? false) {
+            $this->components->success('Webhook registered successfully!');
+
+            return self::SUCCESS;
+        }
+
+        $this->components->error('Failed: '.($result['description'] ?? 'unknown error'));
+
+        return self::FAILURE;
+    }
+
+    private function runWebhookDelete(SupportBotHandler $handler): int
+    {
+        $this->components->info('Removing webhook...');
+
+        $result = $handler->deleteWebhook();
+
+        if ($result['ok'] ?? false) {
+            $this->components->success('Webhook removed.');
+
+            return self::SUCCESS;
+        }
+
+        $this->components->error('Failed: '.($result['description'] ?? 'unknown error'));
+
+        return self::FAILURE;
+    }
+
+    private function runStatus(SupportBotHandler $handler): int
+    {
+        $result = $handler->getBotInfo();
+
+        if (! ($result['ok'] ?? false)) {
+            $this->components->error('Cannot reach Telegram API. Check TELEGRAM_SUPPORT_BOT_TOKEN.');
+
+            return self::FAILURE;
+        }
+
+        $bot = $result['result'];
+
+        $this->components->info('Support bot connected!');
+        $this->table(['Property', 'Value'], [
+            ['Bot name', $bot['first_name'] ?? 'N/A'],
+            ['Bot username', '@'.($bot['username'] ?? 'N/A')],
+            ['Bot ID', (string) ($bot['id'] ?? 'N/A')],
+            ['Support group', config('telegramlogs.support_bot.group_id', '(not set)')],
+            ['Webhook path', config('telegramlogs.support_bot.webhook_path', '/telegram/support/webhook')],
+            ['Webhook secret', config('telegramlogs.support_bot.webhook_secret') ? '✅ set' : '⚠️ not set'],
+        ]);
+
+        $openCount = SupportTicket::whereIn('status', ['open', 'in_progress'])->count();
+        $closedCount = SupportTicket::where('status', 'closed')->count();
+        $this->newLine();
+        $this->line("  Tickets open/in-progress : <info>{$openCount}</info>");
+        $this->line("  Tickets closed           : <info>{$closedCount}</info>");
+
+        return self::SUCCESS;
+    }
+
+    private function runTickets(): int
+    {
+        $limit = (int) $this->option('limit');
+
+        $tickets = SupportTicket::withCount('messages')
+            ->latest()
+            ->limit($limit)
+            ->get();
+
+        if ($tickets->isEmpty()) {
+            $this->components->info('No tickets found.');
+
+            return self::SUCCESS;
+        }
+
+        $this->table(
+            ['Ticket', 'User', 'Username', 'Status', 'Messages', 'Created'],
+            $tickets->map(fn (SupportTicket $t) => [
+                $t->ticket_tag,
+                $t->display_name,
+                $t->username ? "@{$t->username}" : '—',
+                $t->status,
+                $t->messages_count,
+                $t->created_at->format('d/m/Y H:i'),
+            ])->toArray()
+        );
+
+        return self::SUCCESS;
+    }
+
+    private function unknownAction(): int
+    {
+        $this->components->error("Unknown action: {$this->argument('action')}");
+        $this->line('Available: setup | webhook-set | webhook-delete | status | tickets');
+
+        return self::FAILURE;
+    }
+}

--- a/src/Commands/SupportBotCommand.php
+++ b/src/Commands/SupportBotCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Uzhlaravel\Telegramlogs\Commands;
 
 use Illuminate\Console\Command;
+use Uzhlaravel\Telegramlogs\BotRegistry;
 use Uzhlaravel\Telegramlogs\Support\SupportBotHandler;
 use Uzhlaravel\Telegramlogs\Support\SupportTicket;
 
@@ -55,14 +56,24 @@ final class SupportBotCommand extends Command
         $this->line('  <comment>Step 4 — Set environment variables:</comment>');
         $this->newLine();
         $this->line('  <info>Required:</info>');
-        $this->line('  TELEGRAM_SUPPORT_BOT_TOKEN=123456:ABC-your-bot-token');
         $this->line('  TELEGRAM_SUPPORT_GROUP_ID=-100123456789');
+        $this->newLine();
+        $this->line('  <info>Bot token — choose ONE:</info>');
+        $this->line('  <comment>• Single-bot (default):</comment> reuse your logs bot — set nothing extra,');
+        $this->line('    support automatically falls back to TELEGRAM_BOT_TOKEN.');
+        $this->line('  <comment>• Separate support bot:</comment> create a second bot and set:');
+        $this->line('    TELEGRAM_SUPPORT_BOT_TOKEN=123456:ABC-your-support-bot-token');
         $this->newLine();
         $this->line('  <info>Recommended:</info>');
         $this->line('  TELEGRAM_SUPPORT_WEBHOOK_SECRET=a-long-random-string');
         $this->newLine();
         $this->line('  <info>Optional:</info>');
         $this->line('  TELEGRAM_SUPPORT_WEBHOOK_PATH=/telegram/support/webhook');
+        $this->newLine();
+
+        // Reflect the user's current topology.
+        $mode = BotRegistry::isSingleBotMode() ? 'single-bot (support shares the default bot)' : 'multi-bot (dedicated support bot)';
+        $this->line("  <comment>Current mode:</comment> <info>{$mode}</info>");
         $this->newLine();
 
         $this->line('  <comment>Step 5 — Publish and run migrations:</comment>');
@@ -132,10 +143,29 @@ final class SupportBotCommand extends Command
 
     private function runStatus(SupportBotHandler $handler): int
     {
+        // Show the bot topology first (single vs multi-bot).
+        $mode = BotRegistry::isSingleBotMode() ? 'single-bot' : 'multi-bot';
+        $this->components->info("Bot mode: {$mode}");
+
+        $rows = [];
+        foreach (BotRegistry::roles() as $role) {
+            $configured = BotRegistry::isConfigured($role);
+            $dedicated = BotRegistry::hasDedicatedBot($role);
+            $rows[] = [
+                $role,
+                $configured ? '✅ configured' : '⚠️ missing',
+                $role === 'default'
+                    ? '—'
+                    : ($dedicated ? 'own bot' : 'inherits default'),
+            ];
+        }
+        $this->table(['Role', 'Token', 'Resolution'], $rows);
+        $this->newLine();
+
         $result = $handler->getBotInfo();
 
         if (! ($result['ok'] ?? false)) {
-            $this->components->error('Cannot reach Telegram API. Check TELEGRAM_SUPPORT_BOT_TOKEN.');
+            $this->components->error('Cannot reach Telegram API. Check the support bot token (TELEGRAM_SUPPORT_BOT_TOKEN or TELEGRAM_BOT_TOKEN).');
 
             return self::FAILURE;
         }
@@ -147,6 +177,7 @@ final class SupportBotCommand extends Command
             ['Bot name', $bot['first_name'] ?? 'N/A'],
             ['Bot username', '@'.($bot['username'] ?? 'N/A')],
             ['Bot ID', (string) ($bot['id'] ?? 'N/A')],
+            ['Uses dedicated bot', BotRegistry::hasDedicatedBot('support') ? 'yes' : 'no (shares default)'],
             ['Support group', config('telegramlogs.support_bot.group_id', '(not set)')],
             ['Webhook path', config('telegramlogs.support_bot.webhook_path', '/telegram/support/webhook')],
             ['Webhook secret', config('telegramlogs.support_bot.webhook_secret') ? '✅ set' : '⚠️ not set'],

--- a/src/Facades/TelegramSupport.php
+++ b/src/Facades/TelegramSupport.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Uzhlaravel\Telegramlogs\Facades;
+
+use Illuminate\Support\Facades\Facade;
+use Uzhlaravel\Telegramlogs\Support\SupportBotHandler;
+
+/**
+ * @see \Uzhlaravel\Telegramlogs\Support\SupportBotHandler
+ */
+class TelegramSupport extends Facade
+{
+    protected static function getFacadeAccessor(): string
+    {
+        return SupportBotHandler::class;
+    }
+}

--- a/src/Facades/TelegramSupport.php
+++ b/src/Facades/TelegramSupport.php
@@ -8,9 +8,9 @@ use Illuminate\Support\Facades\Facade;
 use Uzhlaravel\Telegramlogs\Support\SupportBotHandler;
 
 /**
- * @see \Uzhlaravel\Telegramlogs\Support\SupportBotHandler
+ * @see SupportBotHandler
  */
-class TelegramSupport extends Facade
+final class TelegramSupport extends Facade
 {
     protected static function getFacadeAccessor(): string
     {

--- a/src/Support/SupportBotHandler.php
+++ b/src/Support/SupportBotHandler.php
@@ -8,6 +8,9 @@ use Exception;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\RequestException;
 use Illuminate\Support\Facades\Log;
+use Uzhlaravel\Telegramlogs\BotRegistry;
+use Uzhlaravel\Telegramlogs\WebChat\WebChatBridge;
+use Uzhlaravel\Telegramlogs\WebChat\WebChatMessage;
 
 /**
  * Telegram Support Bot — tunnel between users (private chat) and staff (group).
@@ -16,7 +19,7 @@ use Illuminate\Support\Facades\Log;
  *   User → private message → bot → group (ticket header + media)
  *   Agent → reply in group  → bot → user (forwarded via copyMessage)
  */
-class SupportBotHandler
+final class SupportBotHandler
 {
     private string $botToken;
 
@@ -28,7 +31,7 @@ class SupportBotHandler
 
     public function __construct()
     {
-        $this->botToken = \Uzhlaravel\Telegramlogs\BotRegistry::token('support');
+        $this->botToken = BotRegistry::token('support');
         $this->supportGroupId = (string) config('telegramlogs.support_bot.group_id', '');
         $this->timeout = (int) config('telegramlogs.timeout', 10);
         $this->client = new Client(['timeout' => $this->timeout]);
@@ -42,6 +45,61 @@ class SupportBotHandler
     {
         if (isset($update['message'])) {
             $this->processMessage($update['message']);
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Webhook management (used by the Artisan command)
+    // ─────────────────────────────────────────────────────────────────────────
+
+    public function setWebhook(string $url, ?string $secret = null): array
+    {
+        try {
+            $payload = ['url' => $url];
+            if ($secret) {
+                $payload['secret_token'] = $secret;
+            }
+
+            $response = $this->client->post(
+                "https://api.telegram.org/bot{$this->botToken}/setWebhook",
+                ['json' => $payload]
+            );
+
+            return json_decode($response->getBody()->getContents(), true) ?? [];
+        } catch (Exception $e) {
+            Log::error('SupportBotHandler::setWebhook failed: '.$e->getMessage());
+
+            return ['ok' => false, 'description' => $e->getMessage()];
+        }
+    }
+
+    public function deleteWebhook(): array
+    {
+        try {
+            $response = $this->client->post(
+                "https://api.telegram.org/bot{$this->botToken}/deleteWebhook"
+            );
+
+            return json_decode($response->getBody()->getContents(), true) ?? [];
+        } catch (Exception $e) {
+            Log::error('SupportBotHandler::deleteWebhook failed: '.$e->getMessage());
+
+            return ['ok' => false, 'description' => $e->getMessage()];
+        }
+    }
+
+    public function getBotInfo(): array
+    {
+        try {
+            $response = $this->client->get(
+                "https://api.telegram.org/bot{$this->botToken}/getMe"
+            );
+
+            return json_decode($response->getBody()->getContents(), true) ?? [];
+        } catch (Exception $e) {
+            Log::error('SupportBotHandler::getBotInfo failed: '.$e->getMessage());
+
+            return ['ok' => false, 'description' => $e->getMessage()];
         }
     }
 
@@ -146,10 +204,10 @@ class SupportBotHandler
         }
 
         // ── Check web chat sessions first ────────────────────────────────────
-        $webChatMsg = \Uzhlaravel\Telegramlogs\WebChat\WebChatMessage::where('group_message_id', $repliedToId)->first();
+        $webChatMsg = WebChatMessage::where('group_message_id', $repliedToId)->first();
 
         if ($webChatMsg) {
-            app(\Uzhlaravel\Telegramlogs\WebChat\WebChatBridge::class)->handleAgentReply($message, $webChatMsg);
+            app(WebChatBridge::class)->handleAgentReply($message, $webChatMsg);
 
             return;
         }
@@ -204,18 +262,18 @@ class SupportBotHandler
 
     private function handleUserCommand(string $command, array $from, string $chatId): void
     {
-        $cmd = strtolower(explode('@', explode(' ', $command)[0])[0]);
+        $cmd = mb_strtolower(explode('@', explode(' ', $command)[0])[0]);
 
         switch ($cmd) {
             case '/start':
                 $name = $from['first_name'] ?? '';
                 $greeting = $name ? "Bonjour {$name}! 👋\n\n" : "Bonjour! 👋\n\n";
                 $this->sendMessage($chatId, $this->cfg('messages.welcome',
-                    $greeting .
-                    "Bienvenue dans notre support. Envoyez-nous votre message, photo ou document et un agent vous répondra.\n\n" .
-                    "Commandes:\n" .
-                    "• /status — état de votre ticket en cours\n" .
-                    "• /help — aide"
+                    $greeting.
+                    "Bienvenue dans notre support. Envoyez-nous votre message, photo ou document et un agent vous répondra.\n\n".
+                    "Commandes:\n".
+                    "• /status — état de votre ticket en cours\n".
+                    '• /help — aide'
                 ));
                 break;
 
@@ -233,9 +291,9 @@ class SupportBotHandler
                     };
                     $count = $ticket->messages()->count();
                     $this->sendMessage($chatId,
-                        "{$emoji} Ticket {$ticket->ticket_tag}\n" .
-                        "Statut : {$ticket->status}\n" .
-                        "Messages échangés : {$count}\n" .
+                        "{$emoji} Ticket {$ticket->ticket_tag}\n".
+                        "Statut : {$ticket->status}\n".
+                        "Messages échangés : {$count}\n".
                         "Ouvert le : {$ticket->created_at->format('d/m/Y à H:i')}"
                     );
                 } else {
@@ -245,10 +303,10 @@ class SupportBotHandler
 
             default:
                 $this->sendMessage($chatId, $this->cfg('messages.help',
-                    "ℹ️ Aide\n\n" .
-                    "Envoyez simplement votre message et un agent vous répondra.\n\n" .
-                    "Vous pouvez envoyer :\n" .
-                    "• Texte\n• Photos\n• Documents\n• Vidéos\n• Messages vocaux\n\n" .
+                    "ℹ️ Aide\n\n".
+                    "Envoyez simplement votre message et un agent vous répondra.\n\n".
+                    "Vous pouvez envoyer :\n".
+                    "• Texte\n• Photos\n• Documents\n• Vidéos\n• Messages vocaux\n\n".
                     "Commandes :\n• /status — état de votre ticket\n• /help — cette aide"
                 ));
                 break;
@@ -271,7 +329,7 @@ class SupportBotHandler
         $ticket = $ticketMessage->ticket;
 
         if ($ticket->isClosed()) {
-            $this->sendMessage($groupChatId, "ℹ️ Ce ticket est déjà fermé.", [
+            $this->sendMessage($groupChatId, 'ℹ️ Ce ticket est déjà fermé.', [
                 'reply_to_message_id' => $message['message_id'],
             ]);
 
@@ -316,12 +374,12 @@ class SupportBotHandler
         $lastActivity = $ticket->last_activity_at?->format('d/m/Y H:i') ?? 'N/A';
 
         $this->sendMessage($groupChatId,
-            "📋 Ticket {$ticket->ticket_tag}\n" .
-            "👤 {$ticket->display_name}{$userTag}\n" .
-            "🆔 ID Telegram : {$ticket->user_telegram_id}\n" .
-            "📊 Statut : {$ticket->status}\n" .
-            "💬 Messages : {$total} ({$byUser} utilisateur / {$byAgent} agent)\n" .
-            "🕐 Ouvert : {$ticket->created_at->format('d/m/Y H:i')}\n" .
+            "📋 Ticket {$ticket->ticket_tag}\n".
+            "👤 {$ticket->display_name}{$userTag}\n".
+            "🆔 ID Telegram : {$ticket->user_telegram_id}\n".
+            "📊 Statut : {$ticket->status}\n".
+            "💬 Messages : {$total} ({$byUser} utilisateur / {$byAgent} agent)\n".
+            "🕐 Ouvert : {$ticket->created_at->format('d/m/Y H:i')}\n".
             "🔄 Dernière activité : {$lastActivity}",
             ['reply_to_message_id' => $message['message_id']]
         );
@@ -476,7 +534,7 @@ class SupportBotHandler
 
     private function agentName(array $from): string
     {
-        return trim(($from['first_name'] ?? 'Agent').' '.($from['last_name'] ?? ''));
+        return mb_trim(($from['first_name'] ?? 'Agent').' '.($from['last_name'] ?? ''));
     }
 
     // ─────────────────────────────────────────────────────────────────────────
@@ -532,61 +590,6 @@ class SupportBotHandler
         }
 
         return [];
-    }
-
-    // ─────────────────────────────────────────────────────────────────────────
-    // Webhook management (used by the Artisan command)
-    // ─────────────────────────────────────────────────────────────────────────
-
-    public function setWebhook(string $url, ?string $secret = null): array
-    {
-        try {
-            $payload = ['url' => $url];
-            if ($secret) {
-                $payload['secret_token'] = $secret;
-            }
-
-            $response = $this->client->post(
-                "https://api.telegram.org/bot{$this->botToken}/setWebhook",
-                ['json' => $payload]
-            );
-
-            return json_decode($response->getBody()->getContents(), true) ?? [];
-        } catch (Exception $e) {
-            Log::error('SupportBotHandler::setWebhook failed: '.$e->getMessage());
-
-            return ['ok' => false, 'description' => $e->getMessage()];
-        }
-    }
-
-    public function deleteWebhook(): array
-    {
-        try {
-            $response = $this->client->post(
-                "https://api.telegram.org/bot{$this->botToken}/deleteWebhook"
-            );
-
-            return json_decode($response->getBody()->getContents(), true) ?? [];
-        } catch (Exception $e) {
-            Log::error('SupportBotHandler::deleteWebhook failed: '.$e->getMessage());
-
-            return ['ok' => false, 'description' => $e->getMessage()];
-        }
-    }
-
-    public function getBotInfo(): array
-    {
-        try {
-            $response = $this->client->get(
-                "https://api.telegram.org/bot{$this->botToken}/getMe"
-            );
-
-            return json_decode($response->getBody()->getContents(), true) ?? [];
-        } catch (Exception $e) {
-            Log::error('SupportBotHandler::getBotInfo failed: '.$e->getMessage());
-
-            return ['ok' => false, 'description' => $e->getMessage()];
-        }
     }
 
     // ─────────────────────────────────────────────────────────────────────────

--- a/src/Support/SupportBotHandler.php
+++ b/src/Support/SupportBotHandler.php
@@ -28,7 +28,7 @@ class SupportBotHandler
 
     public function __construct()
     {
-        $this->botToken = (string) config('telegramlogs.support_bot.bot_token', config('telegramlogs.bot_token', ''));
+        $this->botToken = \Uzhlaravel\Telegramlogs\BotRegistry::token('support');
         $this->supportGroupId = (string) config('telegramlogs.support_bot.group_id', '');
         $this->timeout = (int) config('telegramlogs.timeout', 10);
         $this->client = new Client(['timeout' => $this->timeout]);
@@ -313,6 +313,7 @@ class SupportBotHandler
         $byUser = $ticket->messages()->where('direction', 'user_to_agent')->count();
         $byAgent = $ticket->messages()->where('direction', 'agent_to_user')->count();
         $userTag = $ticket->username ? " (@{$ticket->username})" : '';
+        $lastActivity = $ticket->last_activity_at?->format('d/m/Y H:i') ?? 'N/A';
 
         $this->sendMessage($groupChatId,
             "📋 Ticket {$ticket->ticket_tag}\n" .
@@ -321,7 +322,7 @@ class SupportBotHandler
             "📊 Statut : {$ticket->status}\n" .
             "💬 Messages : {$total} ({$byUser} utilisateur / {$byAgent} agent)\n" .
             "🕐 Ouvert : {$ticket->created_at->format('d/m/Y H:i')}\n" .
-            "🔄 Dernière activité : {$ticket->last_activity_at?->format('d/m/Y H:i') ?? 'N/A'}",
+            "🔄 Dernière activité : {$lastActivity}",
             ['reply_to_message_id' => $message['message_id']]
         );
     }

--- a/src/Support/SupportBotHandler.php
+++ b/src/Support/SupportBotHandler.php
@@ -1,0 +1,590 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Uzhlaravel\Telegramlogs\Support;
+
+use Exception;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\RequestException;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Telegram Support Bot — tunnel between users (private chat) and staff (group).
+ *
+ * Flow:
+ *   User → private message → bot → group (ticket header + media)
+ *   Agent → reply in group  → bot → user (forwarded via copyMessage)
+ */
+class SupportBotHandler
+{
+    private string $botToken;
+
+    private string $supportGroupId;
+
+    private Client $client;
+
+    private int $timeout;
+
+    public function __construct()
+    {
+        $this->botToken = (string) config('telegramlogs.support_bot.bot_token', config('telegramlogs.bot_token', ''));
+        $this->supportGroupId = (string) config('telegramlogs.support_bot.group_id', '');
+        $this->timeout = (int) config('telegramlogs.timeout', 10);
+        $this->client = new Client(['timeout' => $this->timeout]);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Entry point
+    // ─────────────────────────────────────────────────────────────────────────
+
+    public function processUpdate(array $update): void
+    {
+        if (isset($update['message'])) {
+            $this->processMessage($update['message']);
+        }
+    }
+
+    private function processMessage(array $message): void
+    {
+        $chatType = $message['chat']['type'] ?? 'private';
+
+        if ($chatType === 'private') {
+            $this->handleUserMessage($message);
+        } elseif (in_array($chatType, ['group', 'supergroup'], true)) {
+            $this->handleGroupMessage($message);
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // User → Bot (private chat)
+    // ─────────────────────────────────────────────────────────────────────────
+
+    private function handleUserMessage(array $message): void
+    {
+        $from = $message['from'];
+        $chatId = (string) $message['chat']['id'];
+        $text = $message['text'] ?? '';
+
+        if ($text !== '' && str_starts_with($text, '/')) {
+            $this->handleUserCommand($text, $from, $chatId);
+
+            return;
+        }
+
+        $ticket = $this->findOrCreateTicket($from);
+        $isNew = $ticket->wasRecentlyCreated;
+
+        $this->syncUserInfo($ticket, $from);
+
+        // Forward everything to the staff group
+        $groupMessageIds = $this->relayUserMessageToGroup($message, $ticket, $isNew);
+
+        // Persist each group message as a TicketMessage for agent-reply lookup
+        $mediaType = $this->detectMediaType($message);
+
+        foreach ($groupMessageIds as $index => $groupMsgId) {
+            // The last entry is the "content" message (media or text); the first may be the header
+            $isHeaderOnly = $mediaType !== null && $index === 0 && count($groupMessageIds) > 1;
+
+            TicketMessage::create([
+                'ticket_id' => $ticket->id,
+                'direction' => 'user_to_agent',
+                'message_text' => $isHeaderOnly ? null : ($text ?: null),
+                'media_type' => $isHeaderOnly ? null : $mediaType,
+                'media_file_id' => $isHeaderOnly ? null : $this->getFileId($message),
+                'media_caption' => $isHeaderOnly ? null : ($message['caption'] ?? null),
+                'media_file_name' => $isHeaderOnly ? null : $this->getFileName($message),
+                'telegram_message_id' => $message['message_id'],
+                'group_message_id' => $groupMsgId,
+            ]);
+        }
+
+        $ticket->update(['last_activity_at' => now()]);
+
+        if ($isNew) {
+            $this->sendMessage(
+                $chatId,
+                $this->cfg('messages.ticket_created',
+                    "✅ Votre demande a été enregistrée ({$ticket->ticket_tag}).\n\nUn agent va vous répondre dès que possible. Merci de votre patience."
+                )
+            );
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Agent → Bot (group reply)
+    // ─────────────────────────────────────────────────────────────────────────
+
+    private function handleGroupMessage(array $message): void
+    {
+        // Only listen to the configured support group
+        if ((string) $message['chat']['id'] !== $this->supportGroupId) {
+            return;
+        }
+
+        // Agent must reply to a specific message
+        if (! isset($message['reply_to_message'])) {
+            return;
+        }
+
+        $repliedToId = (int) $message['reply_to_message']['message_id'];
+        $from = $message['from'] ?? [];
+        $text = $message['text'] ?? $message['caption'] ?? '';
+
+        // Agent commands
+        if (str_starts_with($text, '/close') || str_starts_with($text, '/fermer')) {
+            $this->handleCloseCommand($repliedToId, $from, $message);
+
+            return;
+        }
+
+        if (str_starts_with($text, '/status') || str_starts_with($text, '/statut')) {
+            $this->handleStatusCommand($repliedToId, $message);
+
+            return;
+        }
+
+        // Find the ticket from the replied-to group message
+        $ticketMessage = TicketMessage::where('group_message_id', $repliedToId)->first();
+
+        if (! $ticketMessage) {
+            return; // Not a ticket-related message — ignore silently
+        }
+
+        $ticket = $ticketMessage->ticket;
+
+        if ($ticket->isClosed()) {
+            $this->sendMessage(
+                (string) $message['chat']['id'],
+                "⚠️ Ce ticket est déjà fermé. Impossible d'envoyer une réponse.",
+                ['reply_to_message_id' => $message['message_id']]
+            );
+
+            return;
+        }
+
+        $agentName = $this->agentName($from);
+        $userChatId = (string) $ticket->user_telegram_id;
+
+        // Copy the agent's message to the user's private chat (no "forwarded from" header)
+        $sentResult = $this->copyMessage($userChatId, (string) $message['chat']['id'], $message['message_id']);
+
+        TicketMessage::create([
+            'ticket_id' => $ticket->id,
+            'direction' => 'agent_to_user',
+            'agent_name' => $agentName,
+            'message_text' => $text ?: null,
+            'media_type' => $this->detectMediaType($message),
+            'media_file_id' => $this->getFileId($message),
+            'media_caption' => $message['caption'] ?? null,
+            'media_file_name' => $this->getFileName($message),
+            'telegram_message_id' => $sentResult['result']['message_id'] ?? null,
+            'group_message_id' => $message['message_id'],
+        ]);
+
+        $ticket->update([
+            'status' => 'in_progress',
+            'last_activity_at' => now(),
+        ]);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Commands
+    // ─────────────────────────────────────────────────────────────────────────
+
+    private function handleUserCommand(string $command, array $from, string $chatId): void
+    {
+        $cmd = strtolower(explode('@', explode(' ', $command)[0])[0]);
+
+        switch ($cmd) {
+            case '/start':
+                $name = $from['first_name'] ?? '';
+                $greeting = $name ? "Bonjour {$name}! 👋\n\n" : "Bonjour! 👋\n\n";
+                $this->sendMessage($chatId, $this->cfg('messages.welcome',
+                    $greeting .
+                    "Bienvenue dans notre support. Envoyez-nous votre message, photo ou document et un agent vous répondra.\n\n" .
+                    "Commandes:\n" .
+                    "• /status — état de votre ticket en cours\n" .
+                    "• /help — aide"
+                ));
+                break;
+
+            case '/status':
+                $ticket = SupportTicket::where('user_telegram_id', $from['id'])
+                    ->whereIn('status', ['open', 'in_progress'])
+                    ->latest()
+                    ->first();
+
+                if ($ticket) {
+                    $emoji = match ($ticket->status) {
+                        'open' => '🔵',
+                        'in_progress' => '🟡',
+                        default => '⚪',
+                    };
+                    $count = $ticket->messages()->count();
+                    $this->sendMessage($chatId,
+                        "{$emoji} Ticket {$ticket->ticket_tag}\n" .
+                        "Statut : {$ticket->status}\n" .
+                        "Messages échangés : {$count}\n" .
+                        "Ouvert le : {$ticket->created_at->format('d/m/Y à H:i')}"
+                    );
+                } else {
+                    $this->sendMessage($chatId, "Vous n'avez pas de ticket ouvert. Envoyez-nous un message pour en créer un.");
+                }
+                break;
+
+            default:
+                $this->sendMessage($chatId, $this->cfg('messages.help',
+                    "ℹ️ Aide\n\n" .
+                    "Envoyez simplement votre message et un agent vous répondra.\n\n" .
+                    "Vous pouvez envoyer :\n" .
+                    "• Texte\n• Photos\n• Documents\n• Vidéos\n• Messages vocaux\n\n" .
+                    "Commandes :\n• /status — état de votre ticket\n• /help — cette aide"
+                ));
+                break;
+        }
+    }
+
+    private function handleCloseCommand(int $repliedToId, array $from, array $message): void
+    {
+        $ticketMessage = TicketMessage::where('group_message_id', $repliedToId)->first();
+        $groupChatId = (string) $message['chat']['id'];
+
+        if (! $ticketMessage) {
+            $this->sendMessage($groupChatId, '❌ Ticket introuvable pour ce message.', [
+                'reply_to_message_id' => $message['message_id'],
+            ]);
+
+            return;
+        }
+
+        $ticket = $ticketMessage->ticket;
+
+        if ($ticket->isClosed()) {
+            $this->sendMessage($groupChatId, "ℹ️ Ce ticket est déjà fermé.", [
+                'reply_to_message_id' => $message['message_id'],
+            ]);
+
+            return;
+        }
+
+        $ticket->update([
+            'status' => 'closed',
+            'closed_at' => now(),
+            'last_activity_at' => now(),
+        ]);
+
+        // Notify user
+        $this->sendMessage((string) $ticket->user_telegram_id, $this->cfg('messages.ticket_closed',
+            "✅ Votre ticket {$ticket->ticket_tag} a été résolu et fermé.\n\nMerci de nous avoir contacté ! Si vous avez d'autres questions, n'hésitez pas à nous écrire."
+        ));
+
+        // Confirm in group
+        $this->sendMessage($groupChatId, "✅ Ticket {$ticket->ticket_tag} fermé par {$this->agentName($from)}.", [
+            'reply_to_message_id' => $message['message_id'],
+        ]);
+    }
+
+    private function handleStatusCommand(int $repliedToId, array $message): void
+    {
+        $ticketMessage = TicketMessage::where('group_message_id', $repliedToId)->first();
+        $groupChatId = (string) $message['chat']['id'];
+
+        if (! $ticketMessage) {
+            $this->sendMessage($groupChatId, '❌ Ticket introuvable pour ce message.', [
+                'reply_to_message_id' => $message['message_id'],
+            ]);
+
+            return;
+        }
+
+        $ticket = $ticketMessage->ticket;
+        $total = $ticket->messages()->count();
+        $byUser = $ticket->messages()->where('direction', 'user_to_agent')->count();
+        $byAgent = $ticket->messages()->where('direction', 'agent_to_user')->count();
+        $userTag = $ticket->username ? " (@{$ticket->username})" : '';
+
+        $this->sendMessage($groupChatId,
+            "📋 Ticket {$ticket->ticket_tag}\n" .
+            "👤 {$ticket->display_name}{$userTag}\n" .
+            "🆔 ID Telegram : {$ticket->user_telegram_id}\n" .
+            "📊 Statut : {$ticket->status}\n" .
+            "💬 Messages : {$total} ({$byUser} utilisateur / {$byAgent} agent)\n" .
+            "🕐 Ouvert : {$ticket->created_at->format('d/m/Y H:i')}\n" .
+            "🔄 Dernière activité : {$ticket->last_activity_at?->format('d/m/Y H:i') ?? 'N/A'}",
+            ['reply_to_message_id' => $message['message_id']]
+        );
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Relay helpers
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /**
+     * Send a user message to the staff group.
+     * Returns an array of group message IDs created (header + optional media copy).
+     *
+     * @return int[]
+     */
+    private function relayUserMessageToGroup(array $message, SupportTicket $ticket, bool $isNew): array
+    {
+        $mediaType = $this->detectMediaType($message);
+        $text = $message['text'] ?? '';
+        $ids = [];
+
+        // Build the header for this message
+        $userTag = $ticket->username ? "@{$ticket->username}" : "ID:{$ticket->user_telegram_id}";
+        $statusBadge = $isNew ? '🆕 Nouveau ticket' : "📨 Ticket {$ticket->ticket_tag}";
+
+        $header = "{$statusBadge}\n";
+        $header .= "👤 {$ticket->display_name} ({$userTag})\n";
+        $header .= '📅 '.now()->format('d/m/Y H:i')."\n";
+
+        if ($mediaType) {
+            $mediaLabel = match ($mediaType) {
+                'photo' => '🖼️ Photo',
+                'document' => '📎 Document'.($this->getFileName($message) ? ' : '.$this->getFileName($message) : ''),
+                'video' => '🎥 Vidéo',
+                'audio' => '🎵 Audio'.($this->getFileName($message) ? ' : '.$this->getFileName($message) : ''),
+                'voice' => '🎤 Message vocal',
+                'sticker' => '🎭 Sticker',
+                'video_note' => '⭕ Vidéo circulaire',
+                default => "📎 {$mediaType}",
+            };
+            $header .= $mediaLabel;
+            if (isset($message['caption'])) {
+                $header .= "\n💬 {$message['caption']}";
+            }
+        } else {
+            $header .= "💬 {$text}";
+        }
+
+        // All subsequent user messages reply to the ticket's anchor message in group
+        $replyOptions = $ticket->group_message_id
+            ? ['reply_to_message_id' => $ticket->group_message_id]
+            : [];
+
+        $headerResult = $this->sendMessage($this->supportGroupId, $header, $replyOptions);
+
+        if ($headerMsgId = $headerResult['result']['message_id'] ?? null) {
+            $ids[] = $headerMsgId;
+
+            // Set the anchor group message on first interaction
+            if (! $ticket->group_message_id) {
+                $ticket->update(['group_message_id' => $headerMsgId]);
+            }
+        }
+
+        // If there is media, copy it to the group as a reply to the header
+        if ($mediaType !== null && isset($headerMsgId)) {
+            $mediaResult = $this->copyMessage(
+                $this->supportGroupId,
+                (string) $message['chat']['id'],
+                $message['message_id'],
+                ['reply_to_message_id' => $headerMsgId]
+            );
+
+            if ($mediaMsgId = $mediaResult['result']['message_id'] ?? null) {
+                $ids[] = $mediaMsgId;
+            }
+        }
+
+        return $ids;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Ticket management
+    // ─────────────────────────────────────────────────────────────────────────
+
+    private function findOrCreateTicket(array $from): SupportTicket
+    {
+        $existing = SupportTicket::where('user_telegram_id', $from['id'])
+            ->whereIn('status', ['open', 'in_progress'])
+            ->latest()
+            ->first();
+
+        if ($existing) {
+            return $existing;
+        }
+
+        return SupportTicket::create([
+            'user_telegram_id' => $from['id'],
+            'username' => $from['username'] ?? null,
+            'first_name' => $from['first_name'] ?? 'Utilisateur',
+            'last_name' => $from['last_name'] ?? null,
+            'status' => 'open',
+        ]);
+    }
+
+    private function syncUserInfo(SupportTicket $ticket, array $from): void
+    {
+        $ticket->update([
+            'username' => $from['username'] ?? $ticket->username,
+            'first_name' => $from['first_name'] ?? $ticket->first_name,
+            'last_name' => $from['last_name'] ?? $ticket->last_name,
+        ]);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Media helpers
+    // ─────────────────────────────────────────────────────────────────────────
+
+    private function detectMediaType(array $message): ?string
+    {
+        foreach (['photo', 'document', 'video', 'audio', 'voice', 'sticker', 'video_note'] as $type) {
+            if (isset($message[$type])) {
+                return $type;
+            }
+        }
+
+        return null;
+    }
+
+    private function getFileId(array $message): ?string
+    {
+        if (isset($message['photo'])) {
+            // Telegram sends multiple sizes; the last one is the highest resolution
+            $photos = $message['photo'];
+
+            return end($photos)['file_id'] ?? null;
+        }
+
+        foreach (['document', 'video', 'audio', 'voice', 'sticker', 'video_note'] as $type) {
+            if (isset($message[$type]['file_id'])) {
+                return $message[$type]['file_id'];
+            }
+        }
+
+        return null;
+    }
+
+    private function getFileName(array $message): ?string
+    {
+        return $message['document']['file_name'] ?? $message['audio']['file_name'] ?? null;
+    }
+
+    private function agentName(array $from): string
+    {
+        return trim(($from['first_name'] ?? 'Agent').' '.($from['last_name'] ?? ''));
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Telegram API calls
+    // ─────────────────────────────────────────────────────────────────────────
+
+    private function sendMessage(string $chatId, string $text, array $options = []): array
+    {
+        try {
+            $payload = array_merge(['chat_id' => $chatId, 'text' => $text], $options);
+
+            $response = $this->client->post(
+                "https://api.telegram.org/bot{$this->botToken}/sendMessage",
+                ['json' => $payload]
+            );
+
+            return json_decode($response->getBody()->getContents(), true) ?? [];
+        } catch (RequestException $e) {
+            Log::error('SupportBotHandler::sendMessage failed', [
+                'chat_id' => $chatId,
+                'error' => $e->getMessage(),
+            ]);
+        } catch (Exception $e) {
+            Log::error('SupportBotHandler::sendMessage unexpected error: '.$e->getMessage());
+        }
+
+        return [];
+    }
+
+    private function copyMessage(string $chatId, string $fromChatId, int $messageId, array $options = []): array
+    {
+        try {
+            $payload = array_merge([
+                'chat_id' => $chatId,
+                'from_chat_id' => $fromChatId,
+                'message_id' => $messageId,
+            ], $options);
+
+            $response = $this->client->post(
+                "https://api.telegram.org/bot{$this->botToken}/copyMessage",
+                ['json' => $payload]
+            );
+
+            return json_decode($response->getBody()->getContents(), true) ?? [];
+        } catch (RequestException $e) {
+            Log::error('SupportBotHandler::copyMessage failed', [
+                'from_chat_id' => $fromChatId,
+                'message_id' => $messageId,
+                'error' => $e->getMessage(),
+            ]);
+        } catch (Exception $e) {
+            Log::error('SupportBotHandler::copyMessage unexpected error: '.$e->getMessage());
+        }
+
+        return [];
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Webhook management (used by the Artisan command)
+    // ─────────────────────────────────────────────────────────────────────────
+
+    public function setWebhook(string $url, ?string $secret = null): array
+    {
+        try {
+            $payload = ['url' => $url];
+            if ($secret) {
+                $payload['secret_token'] = $secret;
+            }
+
+            $response = $this->client->post(
+                "https://api.telegram.org/bot{$this->botToken}/setWebhook",
+                ['json' => $payload]
+            );
+
+            return json_decode($response->getBody()->getContents(), true) ?? [];
+        } catch (Exception $e) {
+            Log::error('SupportBotHandler::setWebhook failed: '.$e->getMessage());
+
+            return ['ok' => false, 'description' => $e->getMessage()];
+        }
+    }
+
+    public function deleteWebhook(): array
+    {
+        try {
+            $response = $this->client->post(
+                "https://api.telegram.org/bot{$this->botToken}/deleteWebhook"
+            );
+
+            return json_decode($response->getBody()->getContents(), true) ?? [];
+        } catch (Exception $e) {
+            Log::error('SupportBotHandler::deleteWebhook failed: '.$e->getMessage());
+
+            return ['ok' => false, 'description' => $e->getMessage()];
+        }
+    }
+
+    public function getBotInfo(): array
+    {
+        try {
+            $response = $this->client->get(
+                "https://api.telegram.org/bot{$this->botToken}/getMe"
+            );
+
+            return json_decode($response->getBody()->getContents(), true) ?? [];
+        } catch (Exception $e) {
+            Log::error('SupportBotHandler::getBotInfo failed: '.$e->getMessage());
+
+            return ['ok' => false, 'description' => $e->getMessage()];
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Config helper
+    // ─────────────────────────────────────────────────────────────────────────
+
+    private function cfg(string $key, string $default): string
+    {
+        return (string) config("telegramlogs.support_bot.{$key}", $default);
+    }
+}

--- a/src/Support/SupportBotHandler.php
+++ b/src/Support/SupportBotHandler.php
@@ -145,7 +145,16 @@ class SupportBotHandler
             return;
         }
 
-        // Find the ticket from the replied-to group message
+        // ── Check web chat sessions first ────────────────────────────────────
+        $webChatMsg = \Uzhlaravel\Telegramlogs\WebChat\WebChatMessage::where('group_message_id', $repliedToId)->first();
+
+        if ($webChatMsg) {
+            app(\Uzhlaravel\Telegramlogs\WebChat\WebChatBridge::class)->handleAgentReply($message, $webChatMsg);
+
+            return;
+        }
+
+        // ── Then check Telegram-to-Telegram tickets ───────────────────────────
         $ticketMessage = TicketMessage::where('group_message_id', $repliedToId)->first();
 
         if (! $ticketMessage) {

--- a/src/Support/SupportTicket.php
+++ b/src/Support/SupportTicket.php
@@ -7,7 +7,7 @@ namespace Uzhlaravel\Telegramlogs\Support;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
-class SupportTicket extends Model
+final class SupportTicket extends Model
 {
     protected $table = 'support_tickets';
 
@@ -47,7 +47,7 @@ class SupportTicket extends Model
 
     public function getDisplayNameAttribute(): string
     {
-        return trim($this->first_name . ' ' . ($this->last_name ?? ''));
+        return mb_trim($this->first_name.' '.($this->last_name ?? ''));
     }
 
     public function getTicketTagAttribute(): string
@@ -59,7 +59,7 @@ class SupportTicket extends Model
     {
         parent::boot();
 
-        static::creating(function (SupportTicket $ticket): void {
+        self::creating(function (SupportTicket $ticket): void {
             if (! $ticket->ticket_number) {
                 $ticket->ticket_number = (static::max('ticket_number') ?? 0) + 1;
             }

--- a/src/Support/SupportTicket.php
+++ b/src/Support/SupportTicket.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Uzhlaravel\Telegramlogs\Support;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class SupportTicket extends Model
+{
+    protected $table = 'support_tickets';
+
+    protected $fillable = [
+        'ticket_number',
+        'user_telegram_id',
+        'username',
+        'first_name',
+        'last_name',
+        'status',
+        'group_message_id',
+        'last_activity_at',
+        'closed_at',
+    ];
+
+    protected $casts = [
+        'user_telegram_id' => 'integer',
+        'group_message_id' => 'integer',
+        'last_activity_at' => 'datetime',
+        'closed_at' => 'datetime',
+    ];
+
+    public function messages(): HasMany
+    {
+        return $this->hasMany(TicketMessage::class, 'ticket_id');
+    }
+
+    public function isOpen(): bool
+    {
+        return $this->status !== 'closed';
+    }
+
+    public function isClosed(): bool
+    {
+        return $this->status === 'closed';
+    }
+
+    public function getDisplayNameAttribute(): string
+    {
+        return trim($this->first_name . ' ' . ($this->last_name ?? ''));
+    }
+
+    public function getTicketTagAttribute(): string
+    {
+        return sprintf('#%04d', $this->ticket_number);
+    }
+
+    protected static function boot(): void
+    {
+        parent::boot();
+
+        static::creating(function (SupportTicket $ticket): void {
+            if (! $ticket->ticket_number) {
+                $ticket->ticket_number = (static::max('ticket_number') ?? 0) + 1;
+            }
+            $ticket->last_activity_at = now();
+        });
+    }
+}

--- a/src/Support/SupportWebhookController.php
+++ b/src/Support/SupportWebhookController.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Uzhlaravel\Telegramlogs\Support;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+class SupportWebhookController extends Controller
+{
+    public function __construct(private readonly SupportBotHandler $handler) {}
+
+    public function __invoke(Request $request): Response
+    {
+        // Verify the Telegram webhook secret if configured
+        $secret = config('telegramlogs.support_bot.webhook_secret');
+
+        if ($secret) {
+            $header = $request->header('X-Telegram-Bot-Api-Secret-Token', '');
+            if (! hash_equals($secret, $header)) {
+                return response('Unauthorized', 403);
+            }
+        }
+
+        $update = $request->all();
+
+        if (empty($update)) {
+            return response('OK', 200);
+        }
+
+        try {
+            $this->handler->processUpdate($update);
+        } catch (Throwable $e) {
+            Log::error('Telegram support webhook error: '.$e->getMessage(), [
+                'update_id' => $update['update_id'] ?? null,
+                'trace' => $e->getTraceAsString(),
+            ]);
+        }
+
+        // Always return 200 so Telegram doesn't retry the update
+        return response('OK', 200);
+    }
+}

--- a/src/Support/SupportWebhookController.php
+++ b/src/Support/SupportWebhookController.php
@@ -10,7 +10,7 @@ use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\Log;
 use Throwable;
 
-class SupportWebhookController extends Controller
+final class SupportWebhookController extends Controller
 {
     public function __construct(private readonly SupportBotHandler $handler) {}
 

--- a/src/Support/TicketMessage.php
+++ b/src/Support/TicketMessage.php
@@ -7,7 +7,7 @@ namespace Uzhlaravel\Telegramlogs\Support;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
-class TicketMessage extends Model
+final class TicketMessage extends Model
 {
     protected $table = 'ticket_messages';
 

--- a/src/Support/TicketMessage.php
+++ b/src/Support/TicketMessage.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Uzhlaravel\Telegramlogs\Support;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class TicketMessage extends Model
+{
+    protected $table = 'ticket_messages';
+
+    protected $fillable = [
+        'ticket_id',
+        'direction',
+        'agent_name',
+        'message_text',
+        'media_type',
+        'media_file_id',
+        'media_caption',
+        'media_file_name',
+        'telegram_message_id',
+        'group_message_id',
+    ];
+
+    protected $casts = [
+        'telegram_message_id' => 'integer',
+        'group_message_id' => 'integer',
+    ];
+
+    public function ticket(): BelongsTo
+    {
+        return $this->belongsTo(SupportTicket::class, 'ticket_id');
+    }
+
+    public function isFromUser(): bool
+    {
+        return $this->direction === 'user_to_agent';
+    }
+
+    public function isFromAgent(): bool
+    {
+        return $this->direction === 'agent_to_user';
+    }
+
+    public function hasMedia(): bool
+    {
+        return $this->media_type !== null;
+    }
+}

--- a/src/TelegramMessage.php
+++ b/src/TelegramMessage.php
@@ -25,7 +25,7 @@ final class TelegramMessage
 
     public function __construct()
     {
-        $this->botToken = config('telegramlogs.bot_token', '');
+        $this->botToken = BotRegistry::token('default');
         $this->chatId = config('telegramlogs.chat_id', '');
         $this->topicId = config('telegramlogs.topic_message_id');
         $this->parseMode = config('telegramlogs.formatting.parse_mode');

--- a/src/TelegramMessage.php
+++ b/src/TelegramMessage.php
@@ -23,9 +23,12 @@ final class TelegramMessage
 
     private ?string $parseMode;
 
-    public function __construct()
+    /**
+     * @param  string  $role  BotRegistry role to use ('default', 'support', or any custom role).
+     */
+    public function __construct(string $role = 'default')
     {
-        $this->botToken = BotRegistry::token('default');
+        $this->botToken = BotRegistry::token($role);
         $this->chatId = config('telegramlogs.chat_id', '');
         $this->topicId = config('telegramlogs.topic_message_id');
         $this->parseMode = config('telegramlogs.formatting.parse_mode');
@@ -34,6 +37,18 @@ final class TelegramMessage
         $this->client = new Client([
             'timeout' => $this->timeout,
         ]);
+    }
+
+    /**
+     * Get a TelegramMessage instance wired to a specific bot role.
+     *
+     * Usage:
+     *   TelegramMessage::forRole('notifications')->toChat('-100xxx', 'Hello!');
+     *   TelegramMessage::forRole('marketing')->message('New campaign live!');
+     */
+    public static function forRole(string $role): self
+    {
+        return new self($role);
     }
 
     /**

--- a/src/Telegramlogs.php
+++ b/src/Telegramlogs.php
@@ -41,7 +41,7 @@ final class Telegramlogs extends AbstractProcessingHandler
     ) {
         parent::__construct($level, $bubble);
 
-        $this->botToken = config('telegramlogs.bot_token') ?? '';
+        $this->botToken = BotRegistry::token('default');
         $this->chatId = config('telegramlogs.chat_id') ?? '';
         $this->topicId = config('telegramlogs.topic_id');
         $this->timeout = $timeout ?? config('telegramlogs.timeout', 10);

--- a/src/TelegramlogsServiceProvider.php
+++ b/src/TelegramlogsServiceProvider.php
@@ -6,7 +6,9 @@ namespace Uzhlaravel\Telegramlogs;
 
 use Illuminate\Support\ServiceProvider;
 use Uzhlaravel\Telegramlogs\Commands\InstallTelegramLogsCommand;
+use Uzhlaravel\Telegramlogs\Commands\SupportBotCommand;
 use Uzhlaravel\Telegramlogs\Commands\TelegramlogsCommand;
+use Uzhlaravel\Telegramlogs\Support\SupportBotHandler;
 
 final class TelegramlogsServiceProvider extends ServiceProvider
 {
@@ -29,6 +31,11 @@ final class TelegramlogsServiceProvider extends ServiceProvider
         $this->app->singleton(ActivityLogger::class, function ($app) {
             return new ActivityLogger($app->make(TelegramMessage::class));
         });
+
+        // Support bot handler — singleton so config is loaded once
+        $this->app->singleton(SupportBotHandler::class, function () {
+            return new SupportBotHandler;
+        });
     }
 
     public function boot(): void
@@ -37,8 +44,18 @@ final class TelegramlogsServiceProvider extends ServiceProvider
             __DIR__.'/../config/telegramlogs.php' => config_path('telegramlogs.php'),
         ], 'telegramlogs-config');
 
+        $this->publishes([
+            __DIR__.'/../database/migrations/create_support_tickets_table.php.stub' => database_path(
+                'migrations/'.date('Y_m_d_His', mktime(0, 0, 0)).'_create_support_tickets_table.php'
+            ),
+            __DIR__.'/../database/migrations/create_ticket_messages_table.php.stub' => database_path(
+                'migrations/'.date('Y_m_d_His', mktime(0, 0, 1)).'_create_ticket_messages_table.php'
+            ),
+        ], 'telegramlogs-support-migrations');
+
         $this->registerCommands();
         $this->addTelegramLogChannel();
+        $this->loadSupportRoutes();
     }
 
     protected function registerCommands(): void
@@ -47,6 +64,7 @@ final class TelegramlogsServiceProvider extends ServiceProvider
             $this->commands([
                 TelegramlogsCommand::class,
                 InstallTelegramLogsCommand::class,
+                SupportBotCommand::class,
             ]);
         }
     }
@@ -64,6 +82,14 @@ final class TelegramlogsServiceProvider extends ServiceProvider
             ]);
 
             config(['logging.channels' => $loggingConfig]);
+        }
+    }
+
+    protected function loadSupportRoutes(): void
+    {
+        // Only register the webhook route when the support bot is configured
+        if (config('telegramlogs.support_bot.bot_token')) {
+            $this->loadRoutesFrom(__DIR__.'/../routes/support.php');
         }
     }
 }

--- a/src/TelegramlogsServiceProvider.php
+++ b/src/TelegramlogsServiceProvider.php
@@ -9,6 +9,7 @@ use Uzhlaravel\Telegramlogs\Commands\InstallTelegramLogsCommand;
 use Uzhlaravel\Telegramlogs\Commands\SupportBotCommand;
 use Uzhlaravel\Telegramlogs\Commands\TelegramlogsCommand;
 use Uzhlaravel\Telegramlogs\Support\SupportBotHandler;
+use Uzhlaravel\Telegramlogs\WebChat\WebChatBridge;
 
 final class TelegramlogsServiceProvider extends ServiceProvider
 {
@@ -36,6 +37,11 @@ final class TelegramlogsServiceProvider extends ServiceProvider
         $this->app->singleton(SupportBotHandler::class, function () {
             return new SupportBotHandler;
         });
+
+        // Web chat bridge — tunnels widget messages to/from Telegram group
+        $this->app->singleton(WebChatBridge::class, function () {
+            return new WebChatBridge;
+        });
     }
 
     public function boot(): void
@@ -53,9 +59,19 @@ final class TelegramlogsServiceProvider extends ServiceProvider
             ),
         ], 'telegramlogs-support-migrations');
 
+        $this->publishes([
+            __DIR__.'/../database/migrations/create_web_chat_sessions_table.php.stub' => database_path(
+                'migrations/'.date('Y_m_d_His', mktime(0, 0, 2)).'_create_web_chat_sessions_table.php'
+            ),
+            __DIR__.'/../database/migrations/create_web_chat_messages_table.php.stub' => database_path(
+                'migrations/'.date('Y_m_d_His', mktime(0, 0, 3)).'_create_web_chat_messages_table.php'
+            ),
+        ], 'telegramlogs-webchat-migrations');
+
         $this->registerCommands();
         $this->addTelegramLogChannel();
         $this->loadSupportRoutes();
+        $this->loadViews();
     }
 
     protected function registerCommands(): void
@@ -87,9 +103,23 @@ final class TelegramlogsServiceProvider extends ServiceProvider
 
     protected function loadSupportRoutes(): void
     {
-        // Only register the webhook route when the support bot is configured
-        if (config('telegramlogs.support_bot.bot_token')) {
+        $hasBotToken = (bool) config('telegramlogs.support_bot.bot_token');
+
+        if ($hasBotToken) {
+            // Telegram-to-Telegram support bot webhook
             $this->loadRoutesFrom(__DIR__.'/../routes/support.php');
+
+            // Web chat widget API (no Telegram account needed for end users)
+            $this->loadRoutesFrom(__DIR__.'/../routes/webchat.php');
         }
+    }
+
+    protected function loadViews(): void
+    {
+        $this->loadViewsFrom(__DIR__.'/../resources/views', 'telegramlogs');
+
+        $this->publishes([
+            __DIR__.'/../resources/views' => resource_path('views/vendor/telegramlogs'),
+        ], 'telegramlogs-views');
     }
 }

--- a/src/TelegramlogsServiceProvider.php
+++ b/src/TelegramlogsServiceProvider.php
@@ -103,9 +103,9 @@ final class TelegramlogsServiceProvider extends ServiceProvider
 
     protected function loadSupportRoutes(): void
     {
-        $hasBotToken = (bool) config('telegramlogs.support_bot.bot_token');
-
-        if ($hasBotToken) {
+        // The support bot resolves to its own token, or falls back to the
+        // default bot when running in single-bot mode.
+        if (BotRegistry::isConfigured('support')) {
             // Telegram-to-Telegram support bot webhook
             $this->loadRoutesFrom(__DIR__.'/../routes/support.php');
 

--- a/src/WebChat/WebChatBridge.php
+++ b/src/WebChat/WebChatBridge.php
@@ -1,0 +1,406 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Uzhlaravel\Telegramlogs\WebChat;
+
+use Exception;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\RequestException;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+
+/**
+ * Bridge between the web chat widget and the Telegram staff group.
+ *
+ * User side: HTTP API polled by the widget (no Telegram account needed).
+ * Agent side: replies in the Telegram staff group via the existing webhook.
+ */
+class WebChatBridge
+{
+    private string $botToken;
+
+    private string $groupId;
+
+    private Client $client;
+
+    public function __construct()
+    {
+        $this->botToken = (string) config('telegramlogs.support_bot.bot_token', config('telegramlogs.bot_token', ''));
+        $this->groupId = (string) config('telegramlogs.support_bot.group_id', '');
+        $this->client = new Client(['timeout' => (int) config('telegramlogs.timeout', 10)]);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // User → Telegram group
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /**
+     * Forward a plain text message from the web user to the staff group.
+     * Returns the Telegram group_message_id for agent-reply lookup.
+     */
+    public function forwardTextToGroup(WebChatSession $session, string $text): ?int
+    {
+        $header = $this->buildSessionHeader($session, isNew: ! $session->group_message_id);
+        $header .= "\n💬 {$text}";
+
+        $options = $session->group_message_id
+            ? ['reply_to_message_id' => $session->group_message_id]
+            : [];
+
+        $result = $this->apiSendMessage($this->groupId, $header, $options);
+        $msgId = $result['result']['message_id'] ?? null;
+
+        if ($msgId && ! $session->group_message_id) {
+            $session->update(['group_message_id' => $msgId]);
+        }
+
+        return $msgId;
+    }
+
+    /**
+     * Upload a file from the web user and forward it to the staff group.
+     * Stores the file locally, sends it to Telegram, then saves the path.
+     *
+     * @return array{group_message_id: ?int, media_path: ?string, media_name: string, media_mime: string, media_size: int}
+     */
+    public function forwardFileToGroup(WebChatSession $session, UploadedFile $file): array
+    {
+        $mediaName = $file->getClientOriginalName();
+        $mediaMime = $file->getMimeType() ?? 'application/octet-stream';
+        $mediaSize = $file->getSize();
+
+        // Store locally so we can serve it to the user later
+        $path = $file->store('webchat/uploads', 'local');
+
+        // Send header to group
+        $isNew = ! $session->group_message_id;
+        $header = $this->buildSessionHeader($session, isNew: $isNew);
+        $isImage = str_starts_with($mediaMime, 'image/');
+        $header .= $isImage ? "\n🖼️ Photo : {$mediaName}" : "\n📎 Fichier : {$mediaName}";
+
+        $headerOptions = $session->group_message_id
+            ? ['reply_to_message_id' => $session->group_message_id]
+            : [];
+
+        $headerResult = $this->apiSendMessage($this->groupId, $header, $headerOptions);
+        $headerMsgId = $headerResult['result']['message_id'] ?? null;
+
+        if ($headerMsgId && $isNew) {
+            $session->update(['group_message_id' => $headerMsgId]);
+        }
+
+        // Send the actual file as reply to the header
+        $fileMsgId = null;
+
+        if ($headerMsgId) {
+            $fileOptions = ['reply_to_message_id' => $headerMsgId];
+            $fileResult = $isImage
+                ? $this->apiSendPhoto($this->groupId, $file->getRealPath(), $fileOptions)
+                : $this->apiSendDocument($this->groupId, $file->getRealPath(), $mediaName, $fileOptions);
+
+            $fileMsgId = $fileResult['result']['message_id'] ?? null;
+        }
+
+        // The media message is what agents reply to (more natural UX)
+        $primaryMsgId = $fileMsgId ?? $headerMsgId;
+
+        return [
+            'group_message_id' => $primaryMsgId,
+            'header_message_id' => $headerMsgId,
+            'media_path' => $path,
+            'media_name' => $mediaName,
+            'media_mime' => $mediaMime,
+            'media_size' => $mediaSize,
+        ];
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Agent → web user (called from the Telegram webhook)
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /**
+     * Handle an agent reply in the staff group for a web chat message.
+     * Saves the reply to DB so the widget can pick it up via polling.
+     */
+    public function handleAgentReply(array $telegramMessage, WebChatMessage $repliedTo): void
+    {
+        $session = $repliedTo->session;
+
+        if ($session->isClosed()) {
+            $this->apiSendMessage(
+                (string) $telegramMessage['chat']['id'],
+                "⚠️ Cette session web est déjà fermée.",
+                ['reply_to_message_id' => $telegramMessage['message_id']]
+            );
+
+            return;
+        }
+
+        $from = $telegramMessage['from'] ?? [];
+        $text = $telegramMessage['text'] ?? $telegramMessage['caption'] ?? '';
+
+        // Agent commands
+        if (str_starts_with($text, '/close') || str_starts_with($text, '/fermer')) {
+            $this->closeSession($session, $from, $telegramMessage);
+
+            return;
+        }
+
+        if (str_starts_with($text, '/status') || str_starts_with($text, '/statut')) {
+            $this->showSessionStatus($session, $telegramMessage);
+
+            return;
+        }
+
+        $agentName = $this->agentName($from);
+        $mediaType = $this->detectMediaType($telegramMessage);
+
+        WebChatMessage::create([
+            'session_id' => $session->id,
+            'direction' => 'agent_to_user',
+            'content' => $text ?: null,
+            'agent_name' => $agentName,
+            'media_file_id' => $mediaType ? $this->getFileId($telegramMessage) : null,
+            'media_name' => $this->getFileName($telegramMessage),
+            'media_mime' => null,
+            'group_message_id' => $telegramMessage['message_id'],
+        ]);
+
+        $session->update([
+            'status' => 'in_progress',
+            'last_activity_at' => now(),
+        ]);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // File download proxy (agent-sent Telegram files → web user)
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /**
+     * Download a Telegram file by its file_id and return the raw bytes + MIME type.
+     * Used by the proxy endpoint so web users can download agent-sent files.
+     *
+     * @return array{content: string, mime: string, name: string}|null
+     */
+    public function downloadTelegramFile(string $fileId): ?array
+    {
+        try {
+            $infoResp = $this->client->get(
+                "https://api.telegram.org/bot{$this->botToken}/getFile?file_id={$fileId}"
+            );
+            $info = json_decode($infoResp->getBody()->getContents(), true);
+
+            if (! ($info['ok'] ?? false)) {
+                return null;
+            }
+
+            $filePath = $info['result']['file_path'];
+            $downloadUrl = "https://api.telegram.org/file/bot{$this->botToken}/{$filePath}";
+
+            $fileResp = $this->client->get($downloadUrl);
+            $content = $fileResp->getBody()->getContents();
+
+            // Guess MIME from path extension
+            $ext = strtolower(pathinfo($filePath, PATHINFO_EXTENSION));
+            $mime = match ($ext) {
+                'jpg', 'jpeg' => 'image/jpeg',
+                'png' => 'image/png',
+                'gif' => 'image/gif',
+                'webp' => 'image/webp',
+                'pdf' => 'application/pdf',
+                'mp4' => 'video/mp4',
+                'mp3' => 'audio/mpeg',
+                'ogg' => 'audio/ogg',
+                default => 'application/octet-stream',
+            };
+
+            return [
+                'content' => $content,
+                'mime' => $mime,
+                'name' => basename($filePath),
+            ];
+        } catch (Exception $e) {
+            Log::error('WebChatBridge::downloadTelegramFile failed: '.$e->getMessage());
+
+            return null;
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Session lifecycle
+    // ─────────────────────────────────────────────────────────────────────────
+
+    private function closeSession(WebChatSession $session, array $from, array $telegramMessage): void
+    {
+        $session->update([
+            'status' => 'closed',
+            'closed_at' => now(),
+            'last_activity_at' => now(),
+        ]);
+
+        // Save a system message so the widget shows "session closed"
+        WebChatMessage::create([
+            'session_id' => $session->id,
+            'direction' => 'agent_to_user',
+            'content' => config(
+                'telegramlogs.web_chat.messages.session_closed',
+                "✅ Votre demande a été résolue et la session est fermée.\n\nMerci de nous avoir contacté ! Si vous avez d'autres questions, ouvrez une nouvelle session."
+            ),
+            'agent_name' => $this->agentName($from),
+            'group_message_id' => $telegramMessage['message_id'],
+        ]);
+
+        $this->apiSendMessage(
+            (string) $telegramMessage['chat']['id'],
+            "✅ Session fermée par {$this->agentName($from)}.",
+            ['reply_to_message_id' => $telegramMessage['message_id']]
+        );
+    }
+
+    private function showSessionStatus(WebChatSession $session, array $telegramMessage): void
+    {
+        $total = $session->messages()->count();
+        $byUser = $session->messages()->where('direction', 'user_to_agent')->count();
+        $byAgent = $session->messages()->where('direction', 'agent_to_user')->count();
+
+        $this->apiSendMessage(
+            (string) $telegramMessage['chat']['id'],
+            "🌐 Session web\n" .
+            "👤 {$session->display_label}\n" .
+            "📊 Statut : {$session->status}\n" .
+            "💬 Messages : {$total} ({$byUser} user / {$byAgent} agent)\n" .
+            "🕐 Ouverture : {$session->created_at->format('d/m/Y H:i')}\n" .
+            "🔄 Dernière activité : {$session->last_activity_at?->format('d/m/Y H:i') ?? 'N/A'}",
+            ['reply_to_message_id' => $telegramMessage['message_id']]
+        );
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Helpers
+    // ─────────────────────────────────────────────────────────────────────────
+
+    private function buildSessionHeader(WebChatSession $session, bool $isNew): string
+    {
+        $badge = $isNew ? '🌐 Nouvelle session web' : '🌐 Session web';
+        $label = $session->display_label;
+        $time = now()->format('d/m/Y H:i');
+
+        return "{$badge}\n👤 {$label}\n📅 {$time}";
+    }
+
+    private function detectMediaType(array $message): ?string
+    {
+        foreach (['photo', 'document', 'video', 'audio', 'voice', 'sticker', 'video_note'] as $type) {
+            if (isset($message[$type])) {
+                return $type;
+            }
+        }
+
+        return null;
+    }
+
+    private function getFileId(array $message): ?string
+    {
+        if (isset($message['photo'])) {
+            $photos = $message['photo'];
+
+            return end($photos)['file_id'] ?? null;
+        }
+        foreach (['document', 'video', 'audio', 'voice', 'sticker', 'video_note'] as $type) {
+            if (isset($message[$type]['file_id'])) {
+                return $message[$type]['file_id'];
+            }
+        }
+
+        return null;
+    }
+
+    private function getFileName(array $message): ?string
+    {
+        return $message['document']['file_name'] ?? $message['audio']['file_name'] ?? null;
+    }
+
+    private function agentName(array $from): string
+    {
+        return trim(($from['first_name'] ?? 'Agent').' '.($from['last_name'] ?? ''));
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Telegram API calls
+    // ─────────────────────────────────────────────────────────────────────────
+
+    private function apiSendMessage(string $chatId, string $text, array $options = []): array
+    {
+        try {
+            $response = $this->client->post(
+                "https://api.telegram.org/bot{$this->botToken}/sendMessage",
+                ['json' => array_merge(['chat_id' => $chatId, 'text' => $text], $options)]
+            );
+
+            return json_decode($response->getBody()->getContents(), true) ?? [];
+        } catch (Exception $e) {
+            Log::error('WebChatBridge::sendMessage: '.$e->getMessage());
+
+            return [];
+        }
+    }
+
+    private function apiSendPhoto(string $chatId, string $filePath, array $options = []): array
+    {
+        try {
+            $response = $this->client->post(
+                "https://api.telegram.org/bot{$this->botToken}/sendPhoto",
+                [
+                    'multipart' => array_merge(
+                        [
+                            ['name' => 'chat_id', 'contents' => $chatId],
+                            ['name' => 'photo', 'contents' => fopen($filePath, 'r'), 'filename' => basename($filePath)],
+                        ],
+                        $this->optionsToMultipart($options)
+                    ),
+                ]
+            );
+
+            return json_decode($response->getBody()->getContents(), true) ?? [];
+        } catch (Exception $e) {
+            Log::error('WebChatBridge::sendPhoto: '.$e->getMessage());
+
+            return [];
+        }
+    }
+
+    private function apiSendDocument(string $chatId, string $filePath, string $fileName, array $options = []): array
+    {
+        try {
+            $response = $this->client->post(
+                "https://api.telegram.org/bot{$this->botToken}/sendDocument",
+                [
+                    'multipart' => array_merge(
+                        [
+                            ['name' => 'chat_id', 'contents' => $chatId],
+                            ['name' => 'document', 'contents' => fopen($filePath, 'r'), 'filename' => $fileName],
+                        ],
+                        $this->optionsToMultipart($options)
+                    ),
+                ]
+            );
+
+            return json_decode($response->getBody()->getContents(), true) ?? [];
+        } catch (Exception $e) {
+            Log::error('WebChatBridge::sendDocument: '.$e->getMessage());
+
+            return [];
+        }
+    }
+
+    private function optionsToMultipart(array $options): array
+    {
+        return array_map(
+            fn ($k, $v) => ['name' => $k, 'contents' => (string) $v],
+            array_keys($options),
+            array_values($options)
+        );
+    }
+}

--- a/src/WebChat/WebChatBridge.php
+++ b/src/WebChat/WebChatBridge.php
@@ -27,7 +27,7 @@ class WebChatBridge
 
     public function __construct()
     {
-        $this->botToken = (string) config('telegramlogs.support_bot.bot_token', config('telegramlogs.bot_token', ''));
+        $this->botToken = \Uzhlaravel\Telegramlogs\BotRegistry::token('support');
         $this->groupId = (string) config('telegramlogs.support_bot.group_id', '');
         $this->client = new Client(['timeout' => (int) config('telegramlogs.timeout', 10)]);
     }
@@ -264,6 +264,7 @@ class WebChatBridge
         $total = $session->messages()->count();
         $byUser = $session->messages()->where('direction', 'user_to_agent')->count();
         $byAgent = $session->messages()->where('direction', 'agent_to_user')->count();
+        $lastActivity = $session->last_activity_at?->format('d/m/Y H:i') ?? 'N/A';
 
         $this->apiSendMessage(
             (string) $telegramMessage['chat']['id'],
@@ -272,7 +273,7 @@ class WebChatBridge
             "📊 Statut : {$session->status}\n" .
             "💬 Messages : {$total} ({$byUser} user / {$byAgent} agent)\n" .
             "🕐 Ouverture : {$session->created_at->format('d/m/Y H:i')}\n" .
-            "🔄 Dernière activité : {$session->last_activity_at?->format('d/m/Y H:i') ?? 'N/A'}",
+            "🔄 Dernière activité : {$lastActivity}",
             ['reply_to_message_id' => $telegramMessage['message_id']]
         );
     }

--- a/src/WebChat/WebChatBridge.php
+++ b/src/WebChat/WebChatBridge.php
@@ -6,10 +6,9 @@ namespace Uzhlaravel\Telegramlogs\WebChat;
 
 use Exception;
 use GuzzleHttp\Client;
-use GuzzleHttp\Exception\RequestException;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Facades\Storage;
+use Uzhlaravel\Telegramlogs\BotRegistry;
 
 /**
  * Bridge between the web chat widget and the Telegram staff group.
@@ -17,7 +16,7 @@ use Illuminate\Support\Facades\Storage;
  * User side: HTTP API polled by the widget (no Telegram account needed).
  * Agent side: replies in the Telegram staff group via the existing webhook.
  */
-class WebChatBridge
+final class WebChatBridge
 {
     private string $botToken;
 
@@ -27,7 +26,7 @@ class WebChatBridge
 
     public function __construct()
     {
-        $this->botToken = \Uzhlaravel\Telegramlogs\BotRegistry::token('support');
+        $this->botToken = BotRegistry::token('support');
         $this->groupId = (string) config('telegramlogs.support_bot.group_id', '');
         $this->client = new Client(['timeout' => (int) config('telegramlogs.timeout', 10)]);
     }
@@ -131,7 +130,7 @@ class WebChatBridge
         if ($session->isClosed()) {
             $this->apiSendMessage(
                 (string) $telegramMessage['chat']['id'],
-                "⚠️ Cette session web est déjà fermée.",
+                '⚠️ Cette session web est déjà fermée.',
                 ['reply_to_message_id' => $telegramMessage['message_id']]
             );
 
@@ -203,7 +202,7 @@ class WebChatBridge
             $content = $fileResp->getBody()->getContents();
 
             // Guess MIME from path extension
-            $ext = strtolower(pathinfo($filePath, PATHINFO_EXTENSION));
+            $ext = mb_strtolower(pathinfo($filePath, PATHINFO_EXTENSION));
             $mime = match ($ext) {
                 'jpg', 'jpeg' => 'image/jpeg',
                 'png' => 'image/png',
@@ -268,11 +267,11 @@ class WebChatBridge
 
         $this->apiSendMessage(
             (string) $telegramMessage['chat']['id'],
-            "🌐 Session web\n" .
-            "👤 {$session->display_label}\n" .
-            "📊 Statut : {$session->status}\n" .
-            "💬 Messages : {$total} ({$byUser} user / {$byAgent} agent)\n" .
-            "🕐 Ouverture : {$session->created_at->format('d/m/Y H:i')}\n" .
+            "🌐 Session web\n".
+            "👤 {$session->display_label}\n".
+            "📊 Statut : {$session->status}\n".
+            "💬 Messages : {$total} ({$byUser} user / {$byAgent} agent)\n".
+            "🕐 Ouverture : {$session->created_at->format('d/m/Y H:i')}\n".
             "🔄 Dernière activité : {$lastActivity}",
             ['reply_to_message_id' => $telegramMessage['message_id']]
         );
@@ -325,7 +324,7 @@ class WebChatBridge
 
     private function agentName(array $from): string
     {
-        return trim(($from['first_name'] ?? 'Agent').' '.($from['last_name'] ?? ''));
+        return mb_trim(($from['first_name'] ?? 'Agent').' '.($from['last_name'] ?? ''));
     }
 
     // ─────────────────────────────────────────────────────────────────────────

--- a/src/WebChat/WebChatController.php
+++ b/src/WebChat/WebChatController.php
@@ -1,0 +1,339 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Uzhlaravel\Telegramlogs\WebChat;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\RateLimiter;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\Validator;
+
+class WebChatController extends Controller
+{
+    public function __construct(private readonly WebChatBridge $bridge) {}
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // POST /telegram-support/chat/start
+    // ─────────────────────────────────────────────────────────────────────────
+
+    public function start(Request $request): JsonResponse
+    {
+        $ip = $request->ip();
+
+        if ($this->tooManyAttempts("webchat-start:{$ip}", 10)) {
+            return response()->json(['error' => 'Too many requests.'], 429);
+        }
+
+        // Resume existing session
+        $token = $request->input('session_token');
+
+        if ($token) {
+            $session = WebChatSession::where('session_token', $token)
+                ->whereIn('status', ['open', 'in_progress'])
+                ->first();
+
+            if ($session) {
+                return response()->json([
+                    'session_token' => $session->session_token,
+                    'resumed' => true,
+                    'status' => $session->status,
+                ]);
+            }
+        }
+
+        // Create a new session
+        $session = WebChatSession::create([
+            'display_name' => $this->sanitize($request->input('name')),
+            'email' => $this->sanitize($request->input('email')),
+            'status' => 'open',
+        ]);
+
+        return response()->json([
+            'session_token' => $session->session_token,
+            'resumed' => false,
+            'status' => 'open',
+        ], 201);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // POST /telegram-support/chat/send
+    // ─────────────────────────────────────────────────────────────────────────
+
+    public function send(Request $request): JsonResponse
+    {
+        $session = $this->resolveSession($request);
+
+        if (! $session) {
+            return response()->json(['error' => 'Session invalide ou expirée.'], 401);
+        }
+
+        if ($session->isClosed()) {
+            return response()->json(['error' => 'Cette session est fermée.'], 422);
+        }
+
+        if ($this->tooManyAttempts("webchat-send:{$session->session_token}", 30)) {
+            return response()->json(['error' => 'Trop de messages. Attendez un moment.'], 429);
+        }
+
+        $text = trim((string) $request->input('message', ''));
+
+        if ($text === '') {
+            return response()->json(['error' => 'Le message ne peut pas être vide.'], 422);
+        }
+
+        if (mb_strlen($text) > 4000) {
+            return response()->json(['error' => 'Message trop long (max 4000 caractères).'], 422);
+        }
+
+        $groupMsgId = $this->bridge->forwardTextToGroup($session, $text);
+
+        $msg = WebChatMessage::create([
+            'session_id' => $session->id,
+            'direction' => 'user_to_agent',
+            'content' => $text,
+            'group_message_id' => $groupMsgId,
+        ]);
+
+        $session->update(['last_activity_at' => now()]);
+
+        return response()->json(['id' => $msg->id]);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // POST /telegram-support/chat/upload
+    // ─────────────────────────────────────────────────────────────────────────
+
+    public function upload(Request $request): JsonResponse
+    {
+        $session = $this->resolveSession($request);
+
+        if (! $session) {
+            return response()->json(['error' => 'Session invalide ou expirée.'], 401);
+        }
+
+        if ($session->isClosed()) {
+            return response()->json(['error' => 'Cette session est fermée.'], 422);
+        }
+
+        if ($this->tooManyAttempts("webchat-upload:{$session->session_token}", 10)) {
+            return response()->json(['error' => 'Trop de fichiers envoyés.'], 429);
+        }
+
+        $maxMb = (int) config('telegramlogs.web_chat.max_upload_mb', 20);
+
+        $validator = Validator::make($request->all(), [
+            'file' => "required|file|max:".($maxMb * 1024),
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json(['error' => $validator->errors()->first('file')], 422);
+        }
+
+        $file = $request->file('file');
+        $result = $this->bridge->forwardFileToGroup($session, $file);
+
+        $msg = WebChatMessage::create([
+            'session_id' => $session->id,
+            'direction' => 'user_to_agent',
+            'content' => null,
+            'media_path' => $result['media_path'],
+            'media_name' => $result['media_name'],
+            'media_mime' => $result['media_mime'],
+            'media_size' => $result['media_size'],
+            'group_message_id' => $result['group_message_id'],
+        ]);
+
+        // Also track the header message if different (so agents can reply to it)
+        if (
+            isset($result['header_message_id']) &&
+            $result['header_message_id'] !== $result['group_message_id']
+        ) {
+            WebChatMessage::create([
+                'session_id' => $session->id,
+                'direction' => 'user_to_agent',
+                'content' => null,
+                'group_message_id' => $result['header_message_id'],
+            ]);
+        }
+
+        $session->update(['last_activity_at' => now()]);
+
+        return response()->json([
+            'id' => $msg->id,
+            'name' => $result['media_name'],
+            'size' => $result['media_size'],
+        ], 201);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // GET /telegram-support/chat/messages?after=0
+    // ─────────────────────────────────────────────────────────────────────────
+
+    public function messages(Request $request): JsonResponse
+    {
+        $session = $this->resolveSession($request);
+
+        if (! $session) {
+            return response()->json(['error' => 'Session invalide.'], 401);
+        }
+
+        $afterId = (int) $request->input('after', 0);
+
+        $messages = WebChatMessage::where('session_id', $session->id)
+            ->where('id', '>', $afterId)
+            ->orderBy('id')
+            ->get()
+            ->map(fn (WebChatMessage $m) => $this->serializeMessage($m));
+
+        return response()->json([
+            'messages' => $messages,
+            'status' => $session->status,
+        ]);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // GET /telegram-support/chat/file/{id}
+    // Proxy to download an agent-sent Telegram file
+    // ─────────────────────────────────────────────────────────────────────────
+
+    public function downloadFile(Request $request, int $messageId): Response
+    {
+        $session = $this->resolveSession($request);
+
+        if (! $session) {
+            abort(401);
+        }
+
+        $msg = WebChatMessage::where('id', $messageId)
+            ->where('session_id', $session->id)
+            ->firstOrFail();
+
+        // User-uploaded file (stored locally)
+        if ($msg->media_path) {
+            $disk = Storage::disk('local');
+
+            if (! $disk->exists($msg->media_path)) {
+                abort(404);
+            }
+
+            return response($disk->get($msg->media_path), 200, [
+                'Content-Type' => $msg->media_mime ?? 'application/octet-stream',
+                'Content-Disposition' => 'inline; filename="'.($msg->media_name ?? 'file').'"',
+            ]);
+        }
+
+        // Agent-sent file from Telegram — proxy download
+        if ($msg->media_file_id) {
+            $file = $this->bridge->downloadTelegramFile($msg->media_file_id);
+
+            if (! $file) {
+                abort(404);
+            }
+
+            $name = $msg->media_name ?? $file['name'];
+
+            return response($file['content'], 200, [
+                'Content-Type' => $file['mime'],
+                'Content-Disposition' => 'inline; filename="'.$name.'"',
+            ]);
+        }
+
+        abort(404);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // GET /telegram-support/widget.js  — embeddable widget script
+    // ─────────────────────────────────────────────────────────────────────────
+
+    public function widgetJs(): Response
+    {
+        $config = json_encode([
+            'baseUrl' => rtrim(config('app.url', ''), '/').'/telegram-support/chat',
+            'title' => config('telegramlogs.web_chat.widget.title', 'Support'),
+            'subtitle' => config('telegramlogs.web_chat.widget.subtitle', 'Nous répondons rapidement'),
+            'color' => config('telegramlogs.web_chat.widget.color', '#0088CC'),
+            'requireName' => config('telegramlogs.web_chat.widget.require_name', false),
+            'placeholder' => config('telegramlogs.web_chat.widget.placeholder', 'Votre message...'),
+            'welcomeMessage' => config('telegramlogs.web_chat.widget.welcome_message', 'Bonjour ! Comment pouvons-nous vous aider ?'),
+            'pollInterval' => (int) config('telegramlogs.web_chat.poll_interval_ms', 3000),
+        ]);
+
+        $html = view('telegramlogs::webchat-widget', ['configJson' => $config])->render();
+
+        // Wrap the Blade HTML as a self-executing JS snippet that injects it
+        $js = <<<JS
+(function() {
+  var div = document.createElement('div');
+  div.innerHTML = {$this->jsString($html)};
+  document.body.appendChild(div.firstElementChild);
+  while (div.firstChild) document.body.appendChild(div.firstChild);
+})();
+JS;
+
+        return response($js, 200, [
+            'Content-Type' => 'application/javascript; charset=utf-8',
+            'Cache-Control' => 'no-cache',
+        ]);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Helpers
+    // ─────────────────────────────────────────────────────────────────────────
+
+    private function resolveSession(Request $request): ?WebChatSession
+    {
+        $token = $request->input('session_token')
+            ?? $request->header('X-Chat-Token');
+
+        if (! $token) {
+            return null;
+        }
+
+        return WebChatSession::where('session_token', $token)->first();
+    }
+
+    private function serializeMessage(WebChatMessage $m): array
+    {
+        $base = [
+            'id' => $m->id,
+            'direction' => $m->direction,
+            'content' => $m->content,
+            'agent_name' => $m->agent_name,
+            'created_at' => $m->created_at?->toISOString(),
+        ];
+
+        if ($m->hasMedia()) {
+            $base['file'] = [
+                'name' => $m->media_name ?? 'fichier',
+                'mime' => $m->media_mime,
+                'size' => $m->media_size,
+                'url' => route('telegram.webchat.file', ['id' => $m->id]),
+            ];
+        }
+
+        return $base;
+    }
+
+    private function tooManyAttempts(string $key, int $maxAttempts): bool
+    {
+        return RateLimiter::tooManyAttempts($key, $maxAttempts);
+    }
+
+    private function sanitize(?string $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        return mb_substr(strip_tags(trim($value)), 0, 255) ?: null;
+    }
+
+    private function jsString(string $html): string
+    {
+        return json_encode($html, JSON_UNESCAPED_UNICODE | JSON_HEX_TAG);
+    }
+}

--- a/src/WebChat/WebChatController.php
+++ b/src/WebChat/WebChatController.php
@@ -12,7 +12,7 @@ use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\Validator;
 
-class WebChatController extends Controller
+final class WebChatController extends Controller
 {
     public function __construct(private readonly WebChatBridge $bridge) {}
 
@@ -79,7 +79,7 @@ class WebChatController extends Controller
             return response()->json(['error' => 'Trop de messages. Attendez un moment.'], 429);
         }
 
-        $text = trim((string) $request->input('message', ''));
+        $text = mb_trim((string) $request->input('message', ''));
 
         if ($text === '') {
             return response()->json(['error' => 'Le message ne peut pas être vide.'], 422);
@@ -126,7 +126,7 @@ class WebChatController extends Controller
         $maxMb = (int) config('telegramlogs.web_chat.max_upload_mb', 20);
 
         $validator = Validator::make($request->all(), [
-            'file' => "required|file|max:".($maxMb * 1024),
+            'file' => 'required|file|max:'.($maxMb * 1024),
         ]);
 
         if ($validator->fails()) {
@@ -252,7 +252,7 @@ class WebChatController extends Controller
     public function widgetJs(): Response
     {
         $config = json_encode([
-            'baseUrl' => rtrim(config('app.url', ''), '/').'/telegram-support/chat',
+            'baseUrl' => mb_rtrim(config('app.url', ''), '/').'/telegram-support/chat',
             'title' => config('telegramlogs.web_chat.widget.title', 'Support'),
             'subtitle' => config('telegramlogs.web_chat.widget.subtitle', 'Nous répondons rapidement'),
             'color' => config('telegramlogs.web_chat.widget.color', '#0088CC'),
@@ -329,7 +329,7 @@ JS;
             return null;
         }
 
-        return mb_substr(strip_tags(trim($value)), 0, 255) ?: null;
+        return mb_substr(strip_tags(mb_trim($value)), 0, 255) ?: null;
     }
 
     private function jsString(string $html): string

--- a/src/WebChat/WebChatMessage.php
+++ b/src/WebChat/WebChatMessage.php
@@ -7,7 +7,7 @@ namespace Uzhlaravel\Telegramlogs\WebChat;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
-class WebChatMessage extends Model
+final class WebChatMessage extends Model
 {
     protected $table = 'web_chat_messages';
 

--- a/src/WebChat/WebChatMessage.php
+++ b/src/WebChat/WebChatMessage.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Uzhlaravel\Telegramlogs\WebChat;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class WebChatMessage extends Model
+{
+    protected $table = 'web_chat_messages';
+
+    protected $fillable = [
+        'session_id',
+        'direction',
+        'content',
+        'agent_name',
+        'media_path',
+        'media_name',
+        'media_mime',
+        'media_size',
+        'media_file_id',
+        'group_message_id',
+        'read_at',
+    ];
+
+    protected $casts = [
+        'group_message_id' => 'integer',
+        'media_size' => 'integer',
+        'read_at' => 'datetime',
+    ];
+
+    public function session(): BelongsTo
+    {
+        return $this->belongsTo(WebChatSession::class, 'session_id');
+    }
+
+    public function isFromUser(): bool
+    {
+        return $this->direction === 'user_to_agent';
+    }
+
+    public function isFromAgent(): bool
+    {
+        return $this->direction === 'agent_to_user';
+    }
+
+    public function hasMedia(): bool
+    {
+        return $this->media_path !== null || $this->media_file_id !== null;
+    }
+}

--- a/src/WebChat/WebChatSession.php
+++ b/src/WebChat/WebChatSession.php
@@ -8,7 +8,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Str;
 
-class WebChatSession extends Model
+final class WebChatSession extends Model
 {
     protected $table = 'web_chat_sessions';
 
@@ -58,7 +58,7 @@ class WebChatSession extends Model
     {
         parent::boot();
 
-        static::creating(function (WebChatSession $session): void {
+        self::creating(function (WebChatSession $session): void {
             if (! $session->session_token) {
                 $session->session_token = (string) Str::uuid();
             }

--- a/src/WebChat/WebChatSession.php
+++ b/src/WebChat/WebChatSession.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Uzhlaravel\Telegramlogs\WebChat;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Str;
+
+class WebChatSession extends Model
+{
+    protected $table = 'web_chat_sessions';
+
+    protected $fillable = [
+        'session_token',
+        'display_name',
+        'email',
+        'status',
+        'group_message_id',
+        'last_activity_at',
+        'closed_at',
+    ];
+
+    protected $casts = [
+        'group_message_id' => 'integer',
+        'last_activity_at' => 'datetime',
+        'closed_at' => 'datetime',
+    ];
+
+    public function messages(): HasMany
+    {
+        return $this->hasMany(WebChatMessage::class, 'session_id');
+    }
+
+    public function isOpen(): bool
+    {
+        return $this->status !== 'closed';
+    }
+
+    public function isClosed(): bool
+    {
+        return $this->status === 'closed';
+    }
+
+    public function getDisplayLabelAttribute(): string
+    {
+        if ($this->display_name) {
+            return $this->email
+                ? "{$this->display_name} ({$this->email})"
+                : $this->display_name;
+        }
+
+        return $this->email ?? 'Visiteur #'.$this->id;
+    }
+
+    protected static function boot(): void
+    {
+        parent::boot();
+
+        static::creating(function (WebChatSession $session): void {
+            if (! $session->session_token) {
+                $session->session_token = (string) Str::uuid();
+            }
+            $session->last_activity_at = now();
+        });
+    }
+}


### PR DESCRIPTION
## Summary

This PR introduces a complete **support ticketing system** and **web chat widget** to the telegramlogs package, enabling user-to-agent communication through Telegram without requiring users to have a Telegram account.

## Key Changes

### Core Support Bot Infrastructure
- **SupportBotHandler** (`src/Support/SupportBotHandler.php`): Main handler for the support bot webhook, managing the bidirectional tunnel between users (private chat) and staff (group chat)
- **BotRegistry** (`src/BotRegistry.php`): New centralized bot token resolver supporting single-bot (default) and multi-bot architectures with automatic fallback
- **SupportTicket & TicketMessage models**: Database models for tracking support tickets and individual messages with full media support
- **SupportWebhookController**: Webhook endpoint for receiving Telegram updates

### Web Chat Widget
- **WebChatBridge** (`src/WebChat/WebChatBridge.php`): Bridge between web users and the Telegram staff group, handling message and file forwarding
- **WebChatController** (`src/WebChat/WebChatController.php`): HTTP API endpoints for the widget (start session, send message, upload file, poll messages)
- **WebChatSession & WebChatMessage models**: Database models for web-only chat sessions
- **webchat-widget.blade.php**: Embeddable chat widget with modern UI, file upload support, and polling-based message retrieval

### Database Migrations
- `create_support_tickets_table.php.stub`: Stores ticket metadata and user info
- `create_ticket_messages_table.php.stub`: Stores individual messages with media metadata
- `create_web_chat_sessions_table.php.stub`: Stores web chat sessions
- `create_web_chat_messages_table.php.stub`: Stores web chat messages

### Configuration & Commands
- **SupportBotCommand** (`src/Commands/SupportBotCommand.php`): Artisan command for setup, webhook management, and ticket inspection
- **config/telegramlogs.php**: New `bots` section for multi-bot configuration and `support_bot` section for ticketing settings
- **TelegramSupport facade**: Convenient access to support bot functionality

### Routing
- **routes/support.php**: Webhook endpoint for Telegram updates
- **routes/webchat.php**: API routes for the web chat widget

## Notable Implementation Details

- **Single-bot by default**: Existing single-bot setups require zero configuration changes; support automatically falls back to the default bot token
- **Multi-bot support**: New `bots` configuration allows splitting logs and support across dedicated bots with transparent fallback
- **Full media support**: Both Telegram and web chat support text, photos, documents, videos, voice messages, audio files, and stickers
- **Agent commands**: `/close` and `/status` commands in the staff group for ticket management
- **Web chat polling**: Widget uses configurable polling interval (default 3s) to fetch new messages without WebSocket overhead
- **File persistence**: Web chat uploads are stored locally and served back to users
- **Rate limiting**: Built-in rate limiting on web chat endpoints to prevent abuse
- **Webhook verification**: Optional secret token verification for webhook security

## Migration Path

The package maintains backward compatibility:
- Existing `TELEGRAM_BOT_TOKEN` continues to work for all roles
- New `TELEGRAM_SUPPORT_BOT_TOKEN` is optional and only used if explicitly set
- All new features are opt-in via configuration

https://claude.ai/code/session_01J7BBWuJeKkLgK6EhB5ZgZR